### PR TITLE
(fr, en, it) add link to examples sandbox in getting-started section

### DIFF
--- a/en/guides/getting-started.md
+++ b/en/guides/getting-started.md
@@ -8,7 +8,7 @@ sort: 0
 
 ## Try Solid
 
-By far the easiest way to get started with Solid is to try it online. Our REPL at https://playground.solidjs.com is the perfect way to try out ideas. As is https://codesandbox.io/ where you can modify any of our Examples.
+By far the easiest way to get started with Solid is to try it online. Our REPL at https://playground.solidjs.com is the perfect way to try out ideas. As is https://codesandbox.io/ where you can modify any of [our Examples](https://github.com/solidjs/solid/blob/main/documentation/resources/examples.md).
 
 Alternatively, you can use our simple [Vite](https://vitejs.dev/) templates by runnings these commands in your terminal:
 

--- a/fr/guides/getting-started.md
+++ b/fr/guides/getting-started.md
@@ -8,7 +8,7 @@ sort: 0
 
 ## Essayer Solid
 
-La manière la plus simple de commencer avec Solid est d'essayer en ligne. Notre REPL sur https://playground.solidjs.com est la meilleure façon d'expérimenter, ainsi que sur https://codesandbox.io/ où vous pouvez modifier nos différents exemples.
+La manière la plus simple de commencer avec Solid est d'essayer en ligne. Notre REPL sur https://playground.solidjs.com est la meilleure façon d'expérimenter, ainsi que sur https://codesandbox.io/ où vous pouvez modifier [nos différents exemples](https://github.com/solidjs/solid/blob/main/documentation/resources/examples.md).
 Sinon, vous pouvez utiliser simplement notre template [Vite](https://vitejs.dev/) en lançant ces commandes dans votre terminal :
 
 ```sh

--- a/it/guides/getting-started.md
+++ b/it/guides/getting-started.md
@@ -8,7 +8,7 @@ sort: 0
 
 ## Prova Solid
 
-Il modo migliore per imparare Solid è provarlo online. Il nostro REPL su https://playground.solidjs.com è il modo perfetto per sperimentare i concetti fondamentali. Così come https://codesandbox.io/ dove puoi modificare uno qualsiasi dei nostri esempi.
+Il modo migliore per imparare Solid è provarlo online. Il nostro REPL su https://playground.solidjs.com è il modo perfetto per sperimentare i concetti fondamentali. Così come https://codesandbox.io/ dove puoi modificare uno qualsiasi dei [nostri esempi](https://github.com/solidjs/solid/blob/main/documentation/resources/examples.md).
 
 In alternativa, puoi utilizzare i nostri semplici modelli [Vite](https://vitejs.dev/) eseguendo questi comandi nel tuo terminale:
 


### PR DESCRIPTION
I was looking for the CodeSandBox mentioned in the documentation, but could find it without asking on Discord.

This is just a suggestion to add a clickable link directly from the getting started section.

Feel free to close it if you rather not include it.

P.S.: I couldn't add it in the Japanese and Chinese translation as I have no clue which term should be clickable, if one of the people speaking those two languages could add them.