### PR TITLE
docs: fix minor typo in 'reactivity - on' lesson.

### DIFF
--- a/en/tutorials/reactivity_on/lesson.md
+++ b/en/tutorials/reactivity_on/lesson.md
@@ -1,4 +1,4 @@
-For convenience, Solid has an `on` helper that enables setting explicit depenencies for our computations. This is mostly used as a terse way to be even more explicit about which Signals are tracked (and not track any other Signals, even if they are read). In addition, `on` provides a `defer` option that allows the computation not to execute immediately and only run on first change.
+For convenience, Solid has an `on` helper that enables setting explicit dependencies for our computations. This is mostly used as a terse way to be even more explicit about which Signals are tracked (and not track any other Signals, even if they are read). In addition, `on` provides a `defer` option that allows the computation not to execute immediately and only run on first change.
 
 Let's have our Effect run only when `a` updates, and defer execution until the value changes:
 


### PR DESCRIPTION
Closes: #38