### PR TITLE
Fix: typo

### DIFF
--- a/langs/en/guides/rendering.md
+++ b/langs/en/guides/rendering.md
@@ -206,7 +206,7 @@ const BasicComponent = (props) => {
 
 // bad
 const BasicComponent = (props) => {
-  const valueProp = prop.value;
+  const valueProp = props.value;
   const value = createMemo(() => valueProp || "default");
   return <div>{value()}</div>;
 };


### PR DESCRIPTION
Fixed a typo.

Before: 
```
const BasicComponent = (props) => {
  const valueProp = prop.value;
  const value = createMemo(() => valueProp || "default");
  return <div>{value()}</div>;
};
```

After:
```
const BasicComponent = (props) => {
  const valueProp = props.value;
  const value = createMemo(() => valueProp || "default");
  return <div>{value()}</div>;
};
```