### PR TITLE
Fix link to server guide

### DIFF
--- a/langs/de/guides/getting-started.md
+++ b/langs/de/guides/getting-started.md
@@ -87,7 +87,7 @@ Solid hat eine dynamische Serverseitige Render-Lösung die eine wirklich isomorp
 
 Da Solid asynchrones Rendern in Datenströme unterstützt, kann man seinen Code einmal schreiben und auch auf dem Server ausführen. Das heisst, das Fähigkeiten wie [render-as-you-fetch](https://reactjs.org/docs/concurrent-mode-suspense.html#approach-3-render-as-you-fetch-using-suspense) und Code-splitting in Solid einfach funktionieren.
 
-Mehr Informationen bietet das [Server Handbuch](#server-side-rendering).
+Mehr Informationen bietet das [Server Handbuch](/guides/server#server-side-rendering).
 
 ## Keine Kompilation?
 

--- a/langs/en/guides/getting-started.md
+++ b/langs/en/guides/getting-started.md
@@ -85,7 +85,7 @@ Solid has a dynamic server side rendering solution that enables a truly isomorph
 
 Since Solid supports asynchronous and stream rendering on the server, you get to write your code one way and have it execute on the server. This means that features like [render-as-you-fetch](https://reactjs.org/docs/concurrent-mode-suspense.html#approach-3-render-as-you-fetch-using-suspense) and code splitting just work in Solid.
 
-For more information, read the [Server guide](#server-side-rendering).
+For more information, read the [Server guide](/guides/server#server-side-rendering).
 
 ## No Compilation?
 

--- a/langs/fr/guides/getting-started.md
+++ b/langs/fr/guides/getting-started.md
@@ -88,7 +88,7 @@ Solid propose une solution dynamique de rendu côté serveur qui permet une vrai
 
 Comme Solid supporte le fonctionnement asynchrone et le stream rendering côté serveur, vous pouvez écrire votre code d'une seule manière et l'exécuter côté serveur. Ce qui veut dire que des fonctionnalités comme [render-as-you-fetch](https://reactjs.org/docs/concurrent-mode-suspense.html#approach-3-render-as-you-fetch-using-suspense) et le fractionnement de code vont fonctionner sans effort avec Solid.
 
-Pour plus d'information, n'hésitez pas à lire le [guide serveur](https://www.solidjs.com/docs/latest#server-side-rendering).
+Pour plus d'information, n'hésitez pas à lire le [guide serveur](https://www.solidjs.com/docs/latest/guides/server#server-side-rendering).
 
 ## Pas de Compilation ?
 

--- a/langs/pt/guides/getting-started.md
+++ b/langs/pt/guides/getting-started.md
@@ -87,7 +87,7 @@ O Solid tem uma solução de renderização dinâmica do lado do servidor que pe
 
 Como o Solid oferece suporte à renderização assíncrona e de fluxo no servidor, você pode escrever seu código de uma maneira e executá-lo no servidor. Isso significa que recursos como [render-as-you-fetch](https://reactjs.org/docs/concurrent-mode-suspense.html#approach-3-render-as-you-fetch-using-suspense) e a divisão de código funciona apenas em Solid.
 
-Para obter mais informações, leia o [Server guide](#server-side-rendering).
+Para obter mais informações, leia o [Server guide](/guides/server#server-side-rendering).
 
 ## Sem Compilação?
 

--- a/langs/ru/guides/getting-started.md
+++ b/langs/ru/guides/getting-started.md
@@ -97,7 +97,7 @@ Solid предлагает решение для динамического ре
 
 Поскольку Solid поддерживает асинхронный и рендеринг с помощью [стримов](https://developer.mozilla.org/ru/docs/Web/API/Streams_API) на сервере, вам не нужно думать об особенностях работы вашего кода на сервере - он будет отлично работать из коробки. Современная архитектура Solid и поддержка стримов означает, что такие фичи, как [render-as-you-fetch](https://ru.reactjs.org/docs/concurrent-mode-suspense.html#approach-3-render-as-you-fetch-using-suspense) и [разделение кода](https://ru.reactjs.org/docs/code-splitting.html) будут работать без проблем.
 
-Для получения дополнительной информации прочтите [Рендеринг на стороне сервера](#server-side-rendering).
+Для получения дополнительной информации прочтите [Рендеринг на стороне сервера](/guides/server#server-side-rendering).
 
 ## Нет компиляции?
 


### PR DESCRIPTION
The link in the Getting Started guide to the Server guide was incorrect.  I fixed all languages.

(At least, I think I got the link format correct. If there's a better way to link between guides, let me know.)