### PR TITLE
Move reasons for owner before example in runWithOwner

### DIFF
--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -332,6 +332,17 @@ Calling `runWithOwner` provides a way to override this default to a manually
 specified owner (typically, the return value from a previous call to
 `getOwner`), enabling more precise control of when computations get disposed.
 
+Having a (correct) owner is important for two reasons:
+
+* Computations without an owner cannot be cleaned up.  For example, if you call
+  `createEffect` without an owner (e.g., in the global scope), the effect will
+  continue running forever, instead of being disposed when its owner gets
+  disposed.
+* [`useContext`](#usecontext) obtains context by walking up the owner tree
+  to find the nearest ancestor providing the desired context.
+  So without an owner you cannot look up any provided context
+  (and with the wrong owner, you might obtain the wrong context).
+
 Manually setting the owner is especially helpful when doing reactivity outside
 of any owner scope.  In particular, asynchronous computation
 (via either `async` functions or callbacks like `setTimeout`)
@@ -342,6 +353,8 @@ For example:
 ```js
 const owner = getOwner();
 setTimeout(() => {
+  // This callback gets run without owner.
+  // Restore owner via runWithOwner:
   runWithOwner(owner, () => {
     const foo = useContext(FooContext);
     createEffect(() => {
@@ -350,17 +363,6 @@ setTimeout(() => {
   });
 }, 1000)
 ```
-
-Having an owner is important for two reasons:
-
-* Computations without an owner cannot be cleaned up.  For example, if you call
-  `createEffect` without an owner (e.g., in the global scope), the effect will
-  continue running forever, instead of being disposed when its owner gets
-  disposed.
-* [`useContext`](#usecontext) obtains context by walking up the owner tree
-  to find the nearest ancestor providing the desired context.
-  So without an owner you cannot look up any provided context
-  (and with the wrong owner, you might obtain the wrong context).
 
 ## `mergeProps`
 


### PR DESCRIPTION
Another helpful comment from @rturnq: explains why we care about restoring owner before showing *how* to do it.

I also added a comment to the example to explain where owner was lost.
