### PR TITLE
createEffect, createRenderEffect, createComputed

### DIFF
--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -210,6 +210,7 @@ their dependencies update (unless you're in a [batch](#batch) or
 [transition](#use-transition)).  For example:
 
 ```js
+// assume this code is in a component function, so is part of a rendering phase
 const [count, setCount] = createSignal(0);
 
 // this effect prints count at the beginning and when it changes
@@ -1189,7 +1190,58 @@ Creates a new computation that automatically tracks dependencies and runs immedi
 export function createRenderEffect<T>(fn: (v: T) => T, value?: T): void;
 ```
 
-Creates a new computation that automatically tracks dependencies and runs during the render phase as DOM elements are created and updated but not necessarily connected. All internal DOM updates happen at this time.
+A render effect is a computation similar to a regular effect
+(as created by [`createEffect`](#createeffect)),
+but differs in when Solid schedules the first execution of the effect function.
+While `createEffect` waits for the current rendering phase to be complete,
+`createRenderEffect` immediately calls the function.
+Thus the effect runs as DOM elements are being created and updated,
+but possibly before specific elements of interest have been created,
+and probably before those elements have been connected to the document.
+In particular, [`ref`](#ref)s will not be set before the initial effect call.
+Indeed, Solid uses `createRenderEffect` to implement the rendering phase
+itself, including setting of `ref`s.
+
+Reactive updates to render effects are identical to effects: they queue up in
+response to a reactive change (e.g., a single signal update, or a `batch` of
+changes, or collective changes during an entire render phase) and run in a
+single [`batch`](#batch) afterward (together with effects).
+In particular, all signal updates within a render effect are batched.
+
+Here is an example of the behavior.
+(Compare with the example in [`createEffect`](#createeffect).)
+
+```js
+// assume this code is in a component function, so is part of a rendering phase
+const [count, setCount] = createSignal(0);
+
+// this effect prints count at the beginning and when it changes
+createRenderEffect(() => console.log('count =', count()));
+// render effect runs immediately, printing `count = 0`
+console.log('hello');
+setCount(1);  // effect won't run yet
+setCount(2);  // effect won't run yet
+
+queueMicrotask(() => {
+  // now `count = 2` will print
+  console.log('microtask');
+  setCount(3);  // immediately prints `count = 3`
+  console.log('goodbye');
+});
+
+// --- overall output: ---
+// count = 0   [this is the only added line compared to createEffect]
+// hello
+// count = 2
+// microtask
+// count = 3
+// goodbye
+```
+
+Just like `createEffect`, the effect function gets called with an argument
+equal to the value returned from the effect function's last execution,
+or on the first call, equal to the optional second argument to
+`createRenderEffect`.
 
 ## `createReaction`
 


### PR DESCRIPTION
* Clarify `createEffect` behavior (fix my previous misunderstanding): `createEffect` generally does not use `queueMicrotask`. That is only when outside a root, which doesn't seem like a crucial behavior to document (and it might plausibly change).
* Flesh out `createRenderEffect` and `createComputed` similar to my previous API rewrites.
* Highlight the differences between these three effect-like computations. After much study and discussion on Discord, I think I got all this right, but it's worth checking.
* Re-order `createComputed` below `createRenderEffect`. I think this makes sense from a presentation perspective: it's easier to describe `createComputed` by how it differs from both `createEffect` and `createRenderEffect`. It also aligns with @ryansolid's general preference (I believe) against `createComputed` and toward `createRenderEffect`. But it could also be argued that `createComputed` is simpler/more fundamental, so maybe makes sense first. I'm happy to go either way.