### PR TITLE
Updated props_split tutorial with example

### DIFF
--- a/langs/en/tutorials/props_split/lesson.md
+++ b/langs/en/tutorials/props_split/lesson.md
@@ -2,6 +2,15 @@ Merging props is not the only operation we can do. Often we use destructuring to
 
 For this purpose, Solid has `splitProps`. It takes the props object and one or more arrays of keys that we want to extract into their own props objects. It returns an array of props objects, one per array of specified keys, plus one props object with any remaining keys, similar to the rest parameter. All returned objects preserve reactivity.
 
+Example:
+  ```code
+   // If original props object contains keys "prop1", "prop2", "prop3", "prop4", "prop5", then executing the following code will return an array of 3 objects as shown below;
+   const [obj1, obj2, objRest] = splitProps(props, ["prop1", "prop2"], ["prop3"]);
+   // obj1 has prop1 and prop2 attributes
+   // obj2 has only prop3 attribute
+   // objRest has the remaining attributes; prop4 and prop5
+  ```
+
 Our example doesn't update when we set the name because of lost reactivity when we destructure in `greeting.tsx`:
 ```jsx
 export default function Greeting(props) {


### PR DESCRIPTION
Added example showing how splitProps method can take multiple arrays as input and return separate objects corresponding to the arrays.