### PR TITLE
Fixed typo

### DIFF
--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -301,7 +301,7 @@ return (
   <ul>
   <li>Your name is "{user()?.name}"</li>
   <li>Your email is <code>{user()?.email}</code></li>
-  </div>
+  </ul>
 );
 ```
 


### PR DESCRIPTION
Fixed typo in createMemo example. The tag opened as `ul` and closed as `div`.