### PR TITLE
Fix "learn more" links on getting-started guide

### DIFF
--- a/langs/de/guides/getting-started.md
+++ b/langs/de/guides/getting-started.md
@@ -55,7 +55,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-Es gibt noch mehr über [Solids Reaktivität](#reactivity) und [Solids Rendering](#rendering) zu lernen.
+Es gibt noch mehr über [Solids Reaktivität](/guides/reactivity) und [Solids Rendering](/guides/rendering) zu lernen.
 
 ## Solids Philosophie
 

--- a/langs/en/guides/getting-started.md
+++ b/langs/en/guides/getting-started.md
@@ -53,7 +53,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-You can learn more about [Solid's Reactivity](#reactivity) and [Solid's Rendering](#rendering).
+You can learn more about [Solid's Reactivity](/guides/reactivity) and [Solid's Rendering](/guides/rendering).
 
 ## Think Solid
 

--- a/langs/es/guides/getting-started.md
+++ b/langs/es/guides/getting-started.md
@@ -55,8 +55,7 @@ const [apellido, setApellido] = createSignal("Bourne");
 createEffect(() => console.log(`${nombre()} ${apellido()}`));
 ```
 
-Puedes aprender mas sobre [Reactividad Solid](#reactivity) y [Renderizado Solid](#rendering).
-Puedes aprender mas sobre [Reactividad Solid](#reactivity) y [Renderizado Solid](#rendering).
+Puedes aprender mas sobre [Reactividad Solid](/guides/reactivity) y [Renderizado Solid](/guides/rendering).
 
 ## Piensa Solid
 

--- a/langs/id/guides/getting-started.md
+++ b/langs/id/guides/getting-started.md
@@ -55,7 +55,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-Kamu dapat mempelajari lebih dalam tentang [Reaktifitas pada Solid](#reaktifitas) dan [Rendering pada Solid](#rendering).
+Kamu dapat mempelajari lebih dalam tentang [Reaktifitas pada Solid](#reaktifitas) dan [Rendering pada Solid](/guides/rendering).
 
 ## Berpikir dengan cara Solid
 

--- a/langs/id/guides/getting-started.md
+++ b/langs/id/guides/getting-started.md
@@ -55,7 +55,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-Kamu dapat mempelajari lebih dalam tentang [Reaktifitas pada Solid](#reaktifitas) dan [Rendering pada Solid](/guides/rendering).
+Kamu dapat mempelajari lebih dalam tentang [Reaktifitas pada Solid](/guides/reactivity) dan [Rendering pada Solid](/guides/rendering).
 
 ## Berpikir dengan cara Solid
 

--- a/langs/it/guides/getting-started.md
+++ b/langs/it/guides/getting-started.md
@@ -55,7 +55,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-Puoi saperne di più su [Reattività di Solid](#reattività) e [Rendering di Solid](#rendering).
+Puoi saperne di più su [Reattività di Solid](#reattività) e [Rendering di Solid](/guides/rendering).
 
 ## Pensa in modo Solid
 

--- a/langs/it/guides/getting-started.md
+++ b/langs/it/guides/getting-started.md
@@ -55,7 +55,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-Puoi saperne di più su [Reattività di Solid](#reattività) e [Rendering di Solid](/guides/rendering).
+Puoi saperne di più su [Reattività di Solid](/guides/reactivity) e [Rendering di Solid](/guides/rendering).
 
 ## Pensa in modo Solid
 

--- a/langs/ko-kr/guides/getting-started.md
+++ b/langs/ko-kr/guides/getting-started.md
@@ -53,7 +53,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-[Solid의 반응성](#reactivity)과 [Solid의 렌더링](#rendering)에 대해서 자세히 알아보세요.
+[Solid의 반응성](/guides/reactivity)과 [Solid의 렌더링](/guides/rendering)에 대해서 자세히 알아보세요.
 
 ## Solid의 철학
 

--- a/langs/pt/guides/getting-started.md
+++ b/langs/pt/guides/getting-started.md
@@ -55,7 +55,7 @@ const [last, setLast] = createSignal("Bourne");
 createEffect(() => console.log(`${first()} ${last()}`));
 ```
 
-Você pode aprender mais sobre [Solid's Reactivity](#reactivity) e [Solid's Rendering](#rendering).
+Você pode aprender mais sobre [Solid's Reactivity](/guides/reactivity) e [Solid's Rendering](/guides/rendering).
 
 ## Pense como Solid
 

--- a/langs/ru/guides/getting-started.md
+++ b/langs/ru/guides/getting-started.md
@@ -61,7 +61,7 @@ createEffect(() => {
 });
 ```
 
-Вы можете узнать больше о [Реактивности Solid](#reactivity) и [Solid Рендеринг](#rendering).
+Вы можете узнать больше о [Реактивности Solid](/guides/reactivity) и [Solid Рендеринг](/guides/rendering).
 
 ## Философия Solid
 


### PR DESCRIPTION
Fix the links to learn more about Solid's Reactivity and Rendering now that those are their own pages