### PR TITLE
Fix typo on "For" lesson

### DIFF
--- a/langs/en/tutorials/flow_for/lesson.md
+++ b/langs/en/tutorials/flow_for/lesson.md
@@ -12,7 +12,7 @@ The `<For>` component is the best way to loop over an array of objects. As the a
 
 There is one prop on the `<For>` component: `each`, where you pass the array to loop over.
 
-Then, instead of writing nodes directly between `<For>` and `</For>`, you a pass a _callback_. This is a function similar to JavaScript's [`map` callback](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#parameters). For each element in the array, the callback is called with the element as the first argument and the index as the second. (`cat` and `i` in this example.) You can then make use of those in the callback, which should return a node to be rendered.
+Then, instead of writing nodes directly between `<For>` and `</For>`, you pass a _callback_. This is a function similar to JavaScript's [`map` callback](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#parameters). For each element in the array, the callback is called with the element as the first argument and the index as the second. (`cat` and `i` in this example.) You can then make use of those in the callback, which should return a node to be rendered.
 
 Note that the index is a _signal_, not a constant number. This is because `<For>` is "keyed by reference": each node that it renders is coupled to an element in the array. In other words, if an element changes placement in the array, rather than being destroyed and recreated, the corresponding node will move too and its index will change.
 


### PR DESCRIPTION
Hello,
Firstly the tutorials are great. Thank you :)

In this PR, I fix a small typo in the `flow_for` lesson.
PS: I have tested with linking with `solid-site`