### PR TITLE
Update API's Setter type to be more accurate, document more complex Setter behavior

### DIFF
--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -38,7 +38,7 @@ function createSignal<T>(
 import type { Signal, Accessor, Setter } from 'solid-js';
 type Signal<T> = [get: Accessor<T>, set: Setter<T>];
 type Accessor<T> = () => T;
-type Setter<T> = (v: T) => T;  // simplified version of real type
+type Setter<T> = (v: T | ((prev?: T) => T)) => T;
 ```
 
 Signals are the most basic reactive primitive.  They track a single value

--- a/langs/en/guides/typescript.md
+++ b/langs/en/guides/typescript.md
@@ -87,6 +87,13 @@ two possibilities for the passed argument: you can call `setCount` with
 a simple `number`, or a
 function taking the previous value (if there was one) and returning a number.
 
+The actual `Setter` type is more complicated, to detect accidentally passing
+a function to the setter when you might have wanted to set the signal to that
+function value instead of calling the function to determine the new value.
+If you're getting a TypeScript error "Argument ... is not assignable to
+parameter" when calling `setCount(value)`, then try wrapping the setter
+argument as in `setCount(() => value)` to make sure that `value` isn't called.
+
 ##### Defaults
 
 We can avoid having to explicitly provide the type of the signal when calling


### PR DESCRIPTION
## Update API's Setter type to be more accurate
This still isn't the full type, which has additional error detection, but it matches the TypeScript guide and is definitely more useful/revealing.

## Document more complex Setter behavior in TypeScript guide
Try to explain the error message you get when passing in a possibly-function type to a setter.