### PR TITLE
Editing pass to remove unnecessary 'simple'/'simply'

### DIFF
--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -754,7 +754,7 @@ import { observable } from "solid-js";
 function observable<T>(input: () => T): Observable<T>;
 ```
 
-This method takes a signal and produces a simple Observable.
+This method takes a signal and produces an Observable.
 You can consume it from another Observable library of your choice, typically
 with the `from` operator.
 
@@ -790,7 +790,7 @@ function from<T>(
 ): () => T;
 ```
 
-A simple helper to make it easier to interopt with external producers like RxJS observables or with Svelte Stores. This basically turns any subscribable (object with a `subscribe` method) into a Signal and manages subscription and disposal.
+A helper to make it easier to interop with external producers like RxJS observables or with Svelte Stores. This basically turns any subscribable (object with a `subscribe` method) into a Signal and manages subscription and disposal.
 
 ```js
 const signal = from(obsv$);
@@ -933,7 +933,8 @@ const [state, setState] = createStore({
 });
 ```
 
-These are simple getters, so you still need to use a memo if you want to cache a value:
+These are getters that rerun when accessed,
+so you still need to use a memo if you want to cache a value:
 
 ```js
 let fullName;
@@ -1604,7 +1605,7 @@ The options are for the `nonce` to be put on the script tag and any event names 
 
 # Control Flow
 
-For reactive control flow to be performant, we have to control how elements are created. For example, with lists, a simple `map` is inefficient as it always maps the entire array.
+For reactive control flow to be performant, we have to control how elements are created. For example, calling `array.map` is inefficient as it always maps the entire array.
 
 This means helper functions. Wrapping these in components is convenient way for terse templating and allows users to compose and build their own control flow components.
 
@@ -1624,7 +1625,8 @@ function For<T, U extends JSX.Element>(props: {
 }): () => U[];
 ```
 
-Simple referentially keyed loop. The callback takes the current item as the first argument:
+A referentially keyed loop with efficient updating of only changed items.
+The callback takes the current item as the first argument:
 
 ```jsx
 <For each={state.list} fallback={<div>Loading...</div>}>
@@ -1690,7 +1692,8 @@ type MatchProps<T> = {
 function Match<T>(props: MatchProps<T>);
 ```
 
-Useful for when there are more than 2 mutual exclusive conditions. Can be used to do things like simple routing.
+Useful for when there are more than 2 mutual exclusive conditions.
+For example, it can be used to perform basic routing:
 
 ```jsx
 <Switch fallback={<div>Not Found</div>}>
@@ -1890,11 +1893,12 @@ declare module "solid-js" {
 Refs are a way of getting access to underlying DOM elements in our JSX. While it is true one could just assign an element to a variable, it is more optimal to leave components in the flow of JSX. Refs are assigned at render time but before the elements are connected to the DOM. They come in 2 flavors.
 
 ```js
-// simple assignment
+// variable assigned directly by ref
 let myDiv;
 
 // use onMount or createEffect to read after connected to DOM
 onMount(() => console.log(myDiv));
+
 <div ref={myDiv} />
 
 // Or, callback function (called before connected to DOM)
@@ -1994,10 +1998,10 @@ function handler(itemId, e) {
 ```
 
 Events are never rebound and the bindings are not reactive, as it is expensive to attach and detach listeners.
-Since event handlers are called like any other function each time an event fires, there is no need for reactivity; simply shortcut your handler if desired.
+Since event handlers are called like any other function each time an event fires, there is no need for reactivity; shortcut your handler if desired.
 
 ```jsx
-// if defined call it, otherwised don't.
+// if defined, call it; otherwise don't.
 <div onClick={() => props.handleClick?.()} />
 ```
 
@@ -2005,7 +2009,7 @@ Note that `onChange` and `onInput` work according to their native behavior. `onI
 
 ## `on:___`/`oncapture:___`
 
-For any other events, perhaps ones with unusual names, or ones you wish not to be delegated there are the `on` namespace events. This simply adds an event listener verbatim.
+For any other events, perhaps ones with unusual names, or ones you wish not to be delegated, there are the `on` namespace events. This attribute adds an event listener verbatim.
 
 ```jsx
 <div on:Weird-Event={(e) => alert(e.detail)} />
@@ -2013,7 +2017,7 @@ For any other events, perhaps ones with unusual names, or ones you wish not to b
 
 ## `use:___`
 
-These are custom directives. In a sense this is just syntax sugar over ref but allows us to easily attach multiple directives to a single element. A directive is simply a function with the following signature:
+These are custom directives. In a sense this is just syntax sugar over ref but allows us to easily attach multiple directives to a single element. A directive is a function with the following signature:
 
 ```ts
 function directive(element: Element, accessor: () => any): void;
@@ -2063,9 +2067,9 @@ Forces the prop to be treated as a attribute instead of an property. Useful for 
 
 ## `/* @once */`
 
-Solid's compiler uses a simple heuristic for reactive wrapping and lazy evaluation of JSX expressions. Does it contain a function call, a property access, or JSX? If yes we wrap it in a getter when passed to components or in an effect if passed to native elements.
+Solid's compiler uses a heuristic for reactive wrapping and lazy evaluation of JSX expressions. Does it contain a function call, a property access, or JSX? If yes we wrap it in a getter when passed to components or in an effect if passed to native elements.
 
-Knowing this we can reduce overhead of things we know will never change simply by accessing them outside of the JSX. A simple variable will never be wrapped. We can also tell the compiler not to wrap them by starting the expression with a comment decorator `/_ @once _/`.
+Knowing this heuristic and its limitations, we can reduce overhead of things we know will never change by accessing them outside of the JSX. A lone variable will never be wrapped. We can also tell the compiler not to wrap them by starting the expression with a comment decorator `/_ @once _/`.
 
 ```jsx
 <MyComponent static={/*@once*/ state.wontUpdate} />

--- a/langs/en/guides/comparison.md
+++ b/langs/en/guides/comparison.md
@@ -76,7 +76,7 @@ This library had the greatest influence on Solid's reactive design. Solid used S
 
 ## RxJS
 
-RxJS is a Reactive library. While Solid has a similar idea of Observable data it uses a much different application of the observer pattern. While Signals are like a simple version of an Observable (only the next), the pattern of auto dependency detection supplants RxJS' hundred or so operators. Solid could have taken this approach, and indeed earlier, versions of the library included similar operators, but in most cases it is more straightforward to write your own transformation logic in a computation. Where Observables are cold starting, unicast and push-based, many problems on the client lend themselves to hot startup and being multicast which is Solid's default behavior.
+RxJS is a Reactive library. While Solid has a similar idea of Observable data it uses a much different application of the observer pattern. While Signals are like a restricted form of an Observable (only the next), the pattern of auto dependency detection supplants RxJS' hundred or so operators. Solid could have taken this approach, and indeed earlier, versions of the library included similar operators, but in most cases it is more straightforward to write your own transformation logic in a computation. Where Observables are cold starting, unicast and push-based, many problems on the client lend themselves to hot startup and being multicast which is Solid's default behavior.
 
 ## Others
 

--- a/langs/en/guides/faq.md
+++ b/langs/en/guides/faq.md
@@ -114,7 +114,7 @@ Other libraries have been adding support for these features but that has been an
 
 Stores automatically wrap nested values making it ideal for deep data structures, and for things like models. For most other things Signals are lightweight and do the job wonderfully.
 
-As much we would love to wrap these together as a single thing, you can't proxy primitives. Functions are the simplest interface and any reactive expression (including state access) can be wrapped in one on transport so this provides a universal API. You can name your signals and state as you choose and it stays minimal. Last thing we'd want to do is force typing `.get()` `.set()` on the end-user or even worse `.value`. At least the former can be aliased for brevity, whereas the latter is just the least terse way to call a function.
+As much we would love to wrap these together as a single thing, you can't proxy primitive values, so in this case we use functions. Any reactive expression (including state access) can be wrapped in a function on transport, so this provides a universal API. You can name your signals and state as you choose and it stays minimal. Last thing we'd want to do is force typing `.get()` `.set()` on the end-user or even worse `.value`. At least the former can be aliased for brevity, whereas the latter is just the least terse way to call a function.
 
 ### Why can I not just assign a value to Solid's Store as I can in Vue, Svelte, or MobX? Where is the 2-way binding?
 

--- a/langs/en/guides/getting-started.md
+++ b/langs/en/guides/getting-started.md
@@ -8,7 +8,7 @@ sort: 0
 
 By far the easiest way to get started with Solid is to try it online. Our REPL at https://playground.solidjs.com is the perfect way to try out ideas. As is https://codesandbox.io/ where you can modify any of [our Examples](https://github.com/solidjs/solid/blob/main/documentation/resources/examples.md).
 
-Alternatively, you can use our simple [Vite templates](https://github.com/solidjs/templates) by running these commands in your terminal:
+Alternatively, you can use our [Vite templates](https://github.com/solidjs/templates) by running these commands in your terminal:
 
 ```sh
 > npx degit solidjs/templates/js my-app
@@ -44,7 +44,7 @@ function MyComponent(props) {
 
 Components are lightweight in that they are not stateful themselves and have no instances. Instead, they serve as factory functions for DOM elements and reactive primitives.
 
-Solid's fine-grained reactivity is built on 3 simple primitives: Signals, Memos, and Effects. Together, they form an auto-tracking synchronization engine that ensures your view stays up to date. Reactive computations take the form of simple function-wrapped expressions that execute synchronously.
+Solid's fine-grained reactivity is built on three core primitives: Signals, Memos, and Effects. Together, they form an auto-tracking synchronization engine that ensures your view stays up to date. Reactive computations take the form of function-wrapped expressions that execute synchronously.
 
 ```js
 const [first, setFirst] = createSignal("JSON");

--- a/langs/en/guides/reactivity.md
+++ b/langs/en/guides/reactivity.md
@@ -29,9 +29,9 @@ render(() => <App />, document.getElementById("app"));
 
 ## Introducing Primitives
 
-Solid is made up of 3 primary primitives, Signal, Memo, and Effect. At their core is the Observer pattern where Signals (and Memos) are tracked by wrapping Memos and Effects.
+Solid is made up of 3 primary primitives: Signal, Memo, and Effect. At their core is the Observer pattern where Signals (and Memos) are tracked by wrapping Memos and Effects.
 
-Signals are the simplest primitive. They contain value, and get and set functions so we can intercept when they are read and written to.
+Signals are the most core primitive. They contain value, and get and set functions so we can intercept when they are read and written to.
 
 ```js
 const [count, setCount] = createSignal(0);

--- a/langs/en/guides/rendering.md
+++ b/langs/en/guides/rendering.md
@@ -44,7 +44,7 @@ import { render } from "solid-js/web";
 render(() => <App />, document.getElementById("main"));
 ```
 
-> **Important** The first argument needs to be a function. Otherwise we can't properly track and schedule the reactive system. This simple ommission will cause your Effects not to run.
+> **Important** The first argument needs to be a function. Otherwise we can't properly track and schedule the reactive system. Omitting the function wrapper will cause your Effects not to run.
 
 ## Components
 

--- a/langs/en/guides/server.md
+++ b/langs/en/guides/server.md
@@ -143,4 +143,4 @@ However, a new starter is in the works [SolidStart](https://github.com/solidjs/s
 
 ## Getting Started with Static Site Generation
 
-[solid-ssr](https://github.com/solidjs/solid/blob/main/packages/solid-ssr) also ships with a simple utility for generating static or prerendered sites. Read the README for more information.
+[solid-ssr](https://github.com/solidjs/solid/blob/main/packages/solid-ssr) also ships with a utility for generating static or prerendered sites. Read the README for more information.

--- a/langs/en/guides/testing.md
+++ b/langs/en/guides/testing.md
@@ -5,7 +5,7 @@ sort: 4
 ---
 # Testing Solid 
 
-To use your Solid code in production, it needs to be tested. Since you don't want to test everything manually, you need automated tests. Testing Solid code can be simple, once you got everything set up and know a few useful patterns for testing.
+To use your Solid code in production, it needs to be tested. Since you don't want to test everything manually, you need automated tests. This guide describes how to set everything up and a few useful patterns for testing Solid code.
 
 ## Testing Setup
 
@@ -497,7 +497,7 @@ clickTest.run();
 
 ### Testing components
 
-Let's take a very simple click-counter component that we want to test:
+Let's take a simple click-counter component that we want to test:
 
 ```ts
 // main.tsx

--- a/langs/en/guides/typescript.md
+++ b/langs/en/guides/typescript.md
@@ -86,8 +86,8 @@ The signal setter `setCount` has type `Setter<number>`, which is a more
 complicated type definition corresponding roughly to
 `(value?: number | ((prev?: number) => number)) => number`, representing the
 two possibilities for the passed argument: you can call `setCount` with 
-a simple `number`, or a
-function taking the previous value (if there was one) and returning a number.
+either a `number` or a
+function taking the previous value (if there was one) and returning a `number`.
 
 The actual `Setter` type is more complicated, to detect accidentally passing
 a function to the setter when you might have wanted to set the signal to that

--- a/langs/en/tutorials/bindings_directives/lesson.md
+++ b/langs/en/tutorials/bindings_directives/lesson.md
@@ -1,10 +1,10 @@
 Solid supports custom directives through the `use:` namespace. This is just a syntactic sugar over `ref`, but is useful in that it resembles typical bindings and there can be multiple bindings on the same element without conflict. This makes it a better tool for reusable DOM element behavior.
 
-Custom directives are simply functions taking arguments `(element, valueAccesor)` where `element` is the DOM element with the `use:` attribute and `valueAccessor` is a getter function for the value assigned to the attribute. As long as the function is imported in scope, you can use it with `use:`.
+A custom directive is a function taking arguments `(element, valueAccesor)`, where `element` is the DOM element with the `use:` attribute, and `valueAccessor` is a getter function for the value assigned to the attribute. As long as the function is imported in scope, you can use it with `use:`.
 
 > Important: `use:` is detected by the compiler to be transformed, and the function is required to be in scope, so it cannot be part of spreads or applied to a component.
 
-In the example, we are going to make a simple wrapper for click-outside behavior to close a popup or modal. First we need to import and use our `clickOutside` directive on our element:
+In the example, we are going to make a wrapper for basic click-outside behavior to close a popup or modal. First we need to import and use our `clickOutside` directive on our element:
 
 ```jsx
 <div class="modal" use:clickOutside={() => setShow(false)}>

--- a/langs/en/tutorials/bindings_refs/lesson.md
+++ b/langs/en/tutorials/bindings_refs/lesson.md
@@ -6,7 +6,7 @@ const myDiv = <div>My Element</div>;
 
 However, there is benefit to not breaking your elements out and instead putting them in a single contiguous JSX template, as it allows Solid to better optimize their creation.
 
-Instead you can get a reference to an element in Solid using the `ref` attribute. Refs are basically assignments like the example above, which happen at creation time before they are attached to the document DOM. Simply declare a variable and it will be assigned to:
+Instead you can get a reference to an element in Solid using the `ref` attribute. Refs are basically assignments like the example above, which happen at creation time before they are attached to the document DOM. Just declare a variable, pass it in as a `ref` attribute, and the variable will be assigned to:
 
 ```jsx
 let myDiv;

--- a/langs/en/tutorials/introduction_jsx/lesson.md
+++ b/langs/en/tutorials/introduction_jsx/lesson.md
@@ -2,7 +2,7 @@ JSX is the HTML-like syntax we've seen inside these examples and is core to buil
 JSX adds dynamic expressions that allow you to reference variables and functions within your HTML by using the `{ } ` syntax.
 In this example, we include the string `name` in our HTML using `{name}` inside a div. In the same way, we include an HTML element that was directly assigned to the `svg` variable.
 
-Unlike some other frameworks that use JSX, Solid attempts to stay as close to HTML standards as possible, allowing simple copy and paste from answers on Stack Overflow or from template builders from your designers.
+Unlike some other frameworks that use JSX, Solid attempts to stay as close to HTML standards as possible, allowing copy and paste from answers on Stack Overflow or from template builders from your designers.
 
 There are 3 main differences between JSX and HTML that prevent JSX from being seen as a superset of HTML:
 1. JSX does not have void elements. This means that all elements must have a closing tag or self-close. Keep this in mind when copying over elements like `<input>` or `<br>`.

--- a/langs/en/tutorials/lifecycles_onmount/lesson.md
+++ b/langs/en/tutorials/lifecycles_onmount/lesson.md
@@ -1,6 +1,6 @@
 There are only a few Lifecycle functions in Solid as everything lives and dies by the reactive system. The reactive system is created and updates synchronously, so the only scheduling comes down to Effects which are pushed to the end of the update.
 
-We've found that developers doing simple tasks don't often think this way, so to make things a
+We've found that developers doing basic tasks don't often think this way, so to make things a
 little easier we've made an alias, `onMount`. `onMount` is just a `createEffect` call that is
 non-tracking, which means it never re-runs. It is just an Effect call but you can use it with confidence
 that it will run only once for your component, once all initial rendering is done.

--- a/langs/en/tutorials/props_defaults/lesson.md
+++ b/langs/en/tutorials/props_defaults/lesson.md
@@ -1,4 +1,4 @@
-Props are what we call the object that is passed to our component function on execution that represents all the attributes bound to its JSX. Props objects are readonly and have reactive properties which are wrapped in Object getters. This allows them to have a consistent form regardless of whether the caller used signals, signal expressions, or simple or static values. You simply access them by `props.propName`.
+Props are what we call the object that is passed to our component function on execution that represents all the attributes bound to its JSX. Props objects are readonly and have reactive properties which are wrapped in Object getters. This allows them to have a consistent form regardless of whether the caller used signals, signal expressions, or static values. You access them by `props.propName`.
 
 For this reason it is also very important to not just destructure props objects, as that would lose reactivity if not done within a tracking scope. In general accessing properties on the props object outside of Solid's primitives or JSX can lose reactivity. This applies not just to destructuring, but also to spreads and functions like `Object.assign`.
 

--- a/langs/en/tutorials/stores_immutable/lesson.md
+++ b/langs/en/tutorials/stores_immutable/lesson.md
@@ -1,6 +1,6 @@
 Stores are most often created in Solid using Solid's Store proxies. Sometimes we wish to interface with immutable libraries like Redux, Apollo, or XState and need to perform granular updates against these.
 
-In the example, we have a simple wrapper around Redux. You can see the implementation in `useRedux.tsx`. The definition of the store and the actions are in the remaining files.
+In the example, we have a basic wrapper around Redux. You can see the implementation in `useRedux.tsx`. The definition of the store and the actions are in the remaining files.
 
 The core behavior is that we created a Store object and subscribe to the Redux store to update state on update.
 

--- a/langs/en/tutorials/stores_nocontext/lesson.md
+++ b/langs/en/tutorials/stores_nocontext/lesson.md
@@ -1,6 +1,6 @@
 Context is a great tool for stores. It handles injection, ties ownership to the reactive graph, automatically manages disposal, and has no render overhead given Solid's fine-grained rendering.
 
-However, you could just use the reactive system directly for simple things. It's almost not worth pointing out but a simple writeable store is just a Signal:
+Sometimes context is overkill, though; an alternative is to use the reactive system directly. For example, we can build a global reactive data store by creating a signal in a global scope, and `export`ing it for other modules to use:
 
 ```js
 import { createSignal } from 'solid-js';

--- a/langs/ko-kr/api.md
+++ b/langs/ko-kr/api.md
@@ -779,7 +779,7 @@ function from<T>(
 ): () => T;
 ```
 
-A simple helper to make it easier to interopt with external producers like RxJS observables or with Svelte Stores. This basically turns any subscribable (object with a `subscribe` method) into a Signal and manages subscription and disposal.
+A simple helper to make it easier to interop with external producers like RxJS observables or with Svelte Stores. This basically turns any subscribable (object with a `subscribe` method) into a Signal and manages subscription and disposal.
 
 ```js
 const signal = from(obsv$);


### PR DESCRIPTION
Some of these changes are less clear and deserve review. I also couldn't resist a bit of copyediting/clarifying/improving as I read the relevant sentences.

Remaining instances of "simpl":
* `### 4. Simple is better than easy` in `getting-started.md`
* `Now whenever we update the Signal we know which Effects to re-run. Simple yet effective.` in `reactivity.md`
* `It's simpler to test the surface of the directive by providing a mounted node and the accessor:` in `testing.md`
* `Let's take a simple click-counter component that we want to test:` in `testing.md`
* ``The simpler fake access `d;` `` in `typescript.md`
* Translations