### PR TITLE
Fix yarn link command

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ These READMEs are also a place for translation maintainers to write any notes ab
 
 This package serves to build the markdown files into a consumable format imported by [solid-site](https://github.com/solidjs/solid-site).
 
-Run `yarn build` to run the build script. This compiles the markdown into various json files in the `dist` folder and turns the `index.ts` file into an entry point that accesses them. Then, to view your changes in the context of the site, clone both repositories and run `yarn link` in the solid-docs directory and `yarn link solid-docs` in the solid-site directory.
+Run `yarn build` to run the build script. This compiles the markdown into various json files in the `dist` folder and turns the `index.ts` file into an entry point that accesses them. Then, to view your changes in the context of the site, clone both repositories and run `yarn link` in the solid-docs directory and `yarn link @solid.js/docs` in the solid-site directory.
 
 After linking, run `yarn watch` in solid-docs to recompile your changes as you make them. Note that adding a new language or a new tutorial directory for a language that didn't have one won't trigger the watcher; run `yarn build` first.
 


### PR DESCRIPTION
When running the instructions to build the docs, I noticed the `yarn link` instruction wasn't quite correct. Here's a fix.