### PR TITLE
fix typo in german translation: lifecycle onmount

### DIFF
--- a/langs/de/tutorials/lifecycles_onmount/lesson.md
+++ b/langs/de/tutorials/lifecycles_onmount/lesson.md
@@ -1,6 +1,6 @@
 Es gibt nur wenige Lifecycle-Methoden in Solid, da alles innerhalb des reaktiven Systems lebt und stirbt. Das reaktive System wird synchron erzeugt und aktualisiert, so dass die einzigen Zwischenschritte in Effekten bestehen, die ans Ende der Aktualisierung geschoben werden.
 
-Wir haben festgestellt, dass Entwickler bei einfachen Aufgaben oft nicht auf diese Weise denken, und um ihnen die Dinge etwas einfacher zhu machen, haben wir einen nicht-verfolgten `createEffect`-Aufruf mit `onMount` verfügbar gemacht. Es ist nur ein Effekt-Aufruf, aber Du kannst ihn in der Sicherheit einsetzen, dass er nur ein Mal pro Komponente laufen wird, sobald diese initial gerendert wurde.
+Wir haben festgestellt, dass Entwickler bei einfachen Aufgaben oft nicht auf diese Weise denken, und um ihnen die Dinge etwas einfacher zu machen, haben wir einen nicht-verfolgten `createEffect`-Aufruf mit `onMount` verfügbar gemacht. Es ist nur ein Effekt-Aufruf, aber Du kannst ihn in der Sicherheit einsetzen, dass er nur ein Mal pro Komponente laufen wird, sobald diese initial gerendert wurde.
 
 Lass uns `onMount` benutzen, um ein paar Photos zu holen:
 ```js


### PR DESCRIPTION
### Fix a typo in the german translation of the tutorial lifecycle onmount:
~~zhu~~ &#8594; zu