### PR TITLE
Document modifyMutable

### DIFF
--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -1218,6 +1218,8 @@ so that dependant computations update just once instead of once per update.
 The first argument is the mutable Store to modify,
 and the second argument is a Store modifier such as those returned by
 [`reconcile`](#reconcile) or [`produce`](#produce).
+(If you pass in your own modifier function, beware that its argument is
+an unwrapped version of the Store.)
 
 For example, suppose we have a UI depending on multiple fields of a mutable:
 

--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -1247,7 +1247,6 @@ To trigger just a single update, we could modify the fields in a `batch`:
 batch(() => {
   state.user.firstName = "Jake";  // triggers update
   state.user.lastName = "Johnson";  // triggers another update
-  // state.user.firstName is still the old value "John" here
 });
 ```
 
@@ -1262,20 +1261,11 @@ modifyMutable(state.user, reconcile({
 });
 
 // Modify two fields in batch, triggering just one update
-modifyMutable(state, produce((s) => {
-  s.user.firstName = "Jake";  // triggers update
-  s.user.lastName = "Johnson";  // triggers another update
-  // s.user.firstName is the new value "Jake" here!
+modifyMutable(state.user, produce((u) => {
+  u.firstName = "Jake";  // triggers update
+  u.lastName = "Johnson";  // triggers another update
 });
 ```
-
-In particular, `modifyMutable(state, produce((s) => { ... }))` avoids
-the counterintuitive behavior that the mutable Store has its old values
-within `batch`, even if it is wrapped within another `batch`:
-within the `{ ... }` code block, all Store values are their latest.
-This makes this pattern suitable for wrapping code that is expecting
-a regular object instead of being aware of reactivity, which can otherwise
-behave poorly when it is wrapped within `batch` or an effect.
 
 # Component APIs
 

--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -1271,9 +1271,11 @@ modifyMutable(state, produce((s) => {
 
 In particular, `modifyMutable(state, produce((s) => { ... }))` avoids
 the counterintuitive behavior that the mutable Store has its old values
-within `batch`; within `produce`, all values are their latest.
+within `batch`, even if it is wrapped within another `batch`:
+within the `{ ... }` code block, all Store values are their latest.
 This makes this pattern suitable for wrapping code that is expecting
-a regular object instead of being aware of reactivity.
+a regular object instead of being aware of reactivity, which can otherwise
+behave poorly when it is wrapped within `batch` or an effect.
 
 # Component APIs
 

--- a/langs/en/api.md
+++ b/langs/en/api.md
@@ -527,7 +527,7 @@ import { batch } from "solid-js";
 function batch<T>(fn: () => T): T;
 ```
 
-Holds committing updates within the block until the end to prevent unnecessary recalculation. This means that reading values on the next line will not have updated yet. [Solid Store](#createstore)'s set method and Effects automatically wrap their code in a batch.
+Holds committing updates within the block until the end to prevent unnecessary recalculation. This means that reading values on the next line will not have updated yet. [Solid Store](#createstore)'s set method, [Mutable Store](#createmutable)'s array methods, and Effects automatically wrap their code in a batch.
 
 ## `on`
 


### PR DESCRIPTION
`modifyMutable` is [documented in the changelog](https://github.com/solidjs/solid/blob/main/CHANGELOG.md#createmutable-batches-array-methods-like-push-pop-etc). This PR adds corresponding documentation to the API document.