### PR TITLE
fix: Broken example

### DIFF
--- a/langs/de/tutorials/bindings_forward_refs/lesson.json
+++ b/langs/de/tutorials/bindings_forward_refs/lesson.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/de/tutorials/bindings_forward_refs/solved.json
+++ b/langs/de/tutorials/bindings_forward_refs/solved.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/de/tutorials/bindings_refs/lesson.json
+++ b/langs/de/tutorials/bindings_refs/lesson.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/de/tutorials/bindings_refs/solved.json
+++ b/langs/de/tutorials/bindings_refs/solved.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/en/tutorials/bindings_forward_refs/lesson.json
+++ b/langs/en/tutorials/bindings_forward_refs/lesson.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/en/tutorials/bindings_forward_refs/solved.json
+++ b/langs/en/tutorials/bindings_forward_refs/solved.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/en/tutorials/bindings_refs/lesson.json
+++ b/langs/en/tutorials/bindings_refs/lesson.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/en/tutorials/bindings_refs/solved.json
+++ b/langs/en/tutorials/bindings_refs/solved.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/it/tutorials/bindings_forward_refs/lesson.json
+++ b/langs/it/tutorials/bindings_forward_refs/lesson.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/it/tutorials/bindings_forward_refs/solved.json
+++ b/langs/it/tutorials/bindings_forward_refs/solved.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/it/tutorials/bindings_refs/lesson.json
+++ b/langs/it/tutorials/bindings_refs/lesson.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/it/tutorials/bindings_refs/solved.json
+++ b/langs/it/tutorials/bindings_refs/solved.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ja/tutorials/bindings_forward_refs/lesson.json
+++ b/langs/ja/tutorials/bindings_forward_refs/lesson.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ja/tutorials/bindings_forward_refs/solved.json
+++ b/langs/ja/tutorials/bindings_forward_refs/solved.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ja/tutorials/bindings_refs/lesson.json
+++ b/langs/ja/tutorials/bindings_refs/lesson.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ja/tutorials/bindings_refs/solved.json
+++ b/langs/ja/tutorials/bindings_refs/solved.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ko-kr/tutorials/bindings_forward_refs/lesson.json
+++ b/langs/ko-kr/tutorials/bindings_forward_refs/lesson.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ko-kr/tutorials/bindings_forward_refs/solved.json
+++ b/langs/ko-kr/tutorials/bindings_forward_refs/solved.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ko-kr/tutorials/bindings_refs/lesson.json
+++ b/langs/ko-kr/tutorials/bindings_refs/lesson.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ko-kr/tutorials/bindings_refs/solved.json
+++ b/langs/ko-kr/tutorials/bindings_refs/solved.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ru/tutorials/bindings_forward_refs/lesson.json
+++ b/langs/ru/tutorials/bindings_forward_refs/lesson.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ru/tutorials/bindings_forward_refs/solved.json
+++ b/langs/ru/tutorials/bindings_forward_refs/solved.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ru/tutorials/bindings_refs/lesson.json
+++ b/langs/ru/tutorials/bindings_refs/lesson.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/ru/tutorials/bindings_refs/solved.json
+++ b/langs/ru/tutorials/bindings_refs/solved.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/zh-cn/tutorials/bindings_forward_refs/lesson.json
+++ b/langs/zh-cn/tutorials/bindings_forward_refs/lesson.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/zh-cn/tutorials/bindings_forward_refs/solved.json
+++ b/langs/zh-cn/tutorials/bindings_forward_refs/solved.json
@@ -11,7 +11,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/zh-cn/tutorials/bindings_refs/lesson.json
+++ b/langs/zh-cn/tutorials/bindings_refs/lesson.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }

--- a/langs/zh-cn/tutorials/bindings_refs/solved.json
+++ b/langs/zh-cn/tutorials/bindings_refs/solved.json
@@ -7,7 +7,7 @@
     {
       "name": "style",
       "type": "css",
-      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://dev.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
+      "content": "canvas {\n  background-color: #666;\n  -webkit-mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n  mask: url(https://www.solidjs.com/img/logo/dark-without-wordmark/logo.svg) 50% 50% no-repeat;\n}"
     }
   ]
 }


### PR DESCRIPTION
## Issues
Fixed an event that prevented samples from working properly. ( https://github.com/solidjs/solid-docs/issues/143 )

## Target Tutorials
https://www.solidjs.com/tutorial/bindings_refs
https://www.solidjs.com/tutorial/bindings_forward_refs

## Causes and Solutions
The URL domain of the image was `https://dev.solidjs.com`, which caused a loading error.
The domain has been changed to `https://www.solidjs.com`.


Thanks.