### PR TITLE
docs: fixed typos in german translation

### DIFF
--- a/langs/de/api/api.md
+++ b/langs/de/api/api.md
@@ -144,7 +144,7 @@ refetch();
 export function onMount(fn: () => void): void;
 ```
 
-Registriert eine Methode, die aufgerufen wirde, nachdem initial gerendert wurde bzw. Elemente geladen wurden. Ideal, um `ref`s zu benutzen oder einmalige Seiteneffekte aufzurufen. Es ist equivalent zu einem `createEffect` ohne Abhängigkeiten.
+Registriert eine Methode, die aufgerufen wurde, nachdem initial gerendert wurde bzw. Elemente geladen wurden. Ideal, um `ref`s zu benutzen oder einmalige Seiteneffekte aufzurufen. Es ist equivalent zu einem `createEffect` ohne Abhängigkeiten.
 
 ## `onCleanup`
 
@@ -219,7 +219,7 @@ setA("new"); // Jetzt läuft der Effekt
 export function createRoot<T>(fn: (dispose: () => void) => T): T;
 ```
 
-Erzeugt einen neuen nicht überwachten Kontext der nicht automatisch aufgeräumt wird. Das ist nützlich für verschachtelte reaktive Kontexte, die nicht aufgeräumt werden sollen, wenn die darüberliegende Komponente neu berechnet wird. Es ist eine mächtige Möglichkeit für Caching.
+Erzeugt einen neuen nicht überwachten Kontext, der nicht automatisch aufgeräumt wird. Das ist nützlich für verschachtelte reaktive Kontexte, die nicht aufgeräumt werden sollen, wenn die darüberliegende Komponente neu berechnet wird. Es ist eine mächtige Möglichkeit für Caching.
 
 Aller Solid-code sollte in einem solchen Kontext eingebunden werden, um sicherzustellen, dass Speicher und Berechnungen aufgeräumt werden. Normalerweise braucht man sich aber nicht darum zu kümmern, da `createRoot` bereits in alle `render`-Funktionen eingebunden ist.
 
@@ -273,7 +273,7 @@ export function useTransition(): [
 ];
 ```
 
-Wird verwendet, um asynchrone Aktualisierungen gemeinsamen auszuführen in einer Transaktion, die solange verzögert wird, bis alle asynchronen Prozesse ausgeführt sind. Dies hängt mit Suspense zusammen und verfolgt ausschließlich Ressourcen innerhalb der Grenzen von Suspense.
+Wird verwendet, um asynchrone Aktualisierungen gemeinsamen auszuführen in einer Transaktion, die so lange verzögert wird, bis alle asynchronen Prozesse ausgeführt sind. Dies hängt mit Suspense zusammen und verfolgt ausschließlich Ressourcen innerhalb der Grenzen von Suspense.
 
 ```js
 const [isPending, start] = useTransition();
@@ -433,7 +433,7 @@ const [state, setState] = createStore({
 fullName = createMemo(() => `${state.firstName} ${state.lastName}`);
 ```
 
-### Stores aktualsieren
+### Stores aktualisieren
 
 Änderungen können die Form von Funktionen annehmen, die den vorherigen Zustand übergeben bekommen und den neuen Zustand oder Wert ausgeben. Objekte werden immer nur auf der obersten Ebene zusammengeführt. Man kann Werte auf `undefined` setzen, um sie aus dem Store zu entfernen.
 
@@ -476,7 +476,7 @@ setState('list', 2, 'read', true);
 // }
 ```
 
-Der Pfad kann String-Keys, Arrays von String-Keys, Objekte mit Beschreibung einer Iteration ({from, to, by}), oder Filterfunktionen sein. Das gibt erstaundliche Ausdrucksvielfalt, Zustandsveränderungen zu beschreiben.
+Der Pfad kann String-Keys, Arrays von String-Keys, Objekte mit Beschreibung einer Iteration ({from, to, by}), oder Filterfunktionen sein. Das gibt erstaunliche Ausdrucksvielfalt, Zustandsveränderungen zu beschreiben.
 
 ```js
 const [state, setState] = createStore({
@@ -628,7 +628,7 @@ export function createContext<T>(defaultValue?: T): Context<T | undefined>;
 
 Context erlaubt eine Art Abhängigkeitsinjektion in Solid. Es wird verwendet, um zu verhindern, dass Daten als Props durch dazwischen liegende Komponenten hindurch weitergegeben werden muss.
 
-Diese Funktion erzeugt ein neues Kontext-Objekt, das mit `useContext` verwerdet werden kann und den `Provider`-Kontrollfluss enthält. Der Standardwert des Kontexts wird verwendet, wenn kein `Provider` in der Hierarchie gefunden werden kann.
+Diese Funktion erzeugt ein neues Kontext-Objekt, das mit `useContext` verwendet werden kann und den `Provider`-Kontrollfluss enthält. Der Standardwert des Kontexts wird verwendet, wenn kein `Provider` in der Hierarchie gefunden werden kann.
 
 ```js
 export const CounterContext = createContext([{ count: 0 }, {}]);
@@ -731,7 +731,7 @@ export function createComputed<T>(
 ): void;
 ```
 
-Erzeutt eine neue Berechnung, die automatisch Abhängigkeiten verfolgt und direkt vor dem Rendern läuft. Wird verwendet, um in andere reaktive Primitiven zu schreiben. Wenn möglich, sollte stattdessen `createMemo` verwendet werden, da das Schreiben in ein Signal während einer Aktualisierung andere Berechnungen neu starten lassen kann.
+Erzeugt eine neue Berechnung, die automatisch Abhängigkeiten verfolgt und direkt vor dem Rendern läuft. Wird verwendet, um in andere reaktive Primitiven zu schreiben. Wenn möglich, sollte stattdessen `createMemo` verwendet werden, da das Schreiben in ein Signal während einer Aktualisierung andere Berechnungen neu starten lassen kann.
 
 ## `createRenderEffect`
 
@@ -975,7 +975,7 @@ Der Show-Kontrollfluss wird verwendet, um das Rendern einer Komponente von einer
 </Show>
 ```
 
-Show kann auch benutzt werden, um Inhalte an ein bestimmtes Datenmodell zu koppeln. Bspw. wird die Funktion erneut ausgeführt, wennn das User-Model ersetzt wird.
+Show kann auch benutzt werden, um Inhalte an ein bestimmtes Datenmodell zu koppeln. Bsp. wird die Funktion erneut ausgeführt, wenn das User-Model ersetzt wird.
 
 ```jsx
 <Show when={state.user} fallback={<div>Loading...</div>}>
@@ -1054,7 +1054,7 @@ function ErrorBoundary(props: {
 }): () => JSX.Element;
 ```
 
-Fängt ungefangene Fehler und rendert Fallback-Inhalte.
+Fängt nicht abgefangene Fehler und rendert Fallback-Inhalte.
 
 ```jsx
 <ErrorBoundary fallback={<div>Something went terribly wrong</div>}>
@@ -1250,7 +1250,7 @@ Die beiden funktionieren genauso wie die entsprechenden Eigenschaften. Wenn man 
 
 ## `on___`
 
-Event-Handler in Solid haben typischerweise die Form von `onclick` oder `onClick` je nach Stil. Der Event-Name ist immer klein geschrieben. Solid verwendet halb-synthetische Event-Delegation für normale UI-Events, die zusammengesetzt werden und bubbeln. Das verbessert die Geschwindigkeit dieser gewöhnlichen Events.
+Event-Handler in Solid haben typischerweise die Form von `onclick` oder `onClick` je nach Stil. Der Event-Name ist immer kleingeschrieben. Solid verwendet halb-synthetische Event-Delegation für normale UI-Events, die zusammengesetzt werden und bubbeln. Das verbessert die Geschwindigkeit dieser gewöhnlichen Events.
 
 ```jsx
 <div onClick={(e) => console.log(e.currentTarget)} />
@@ -1337,7 +1337,7 @@ Erzwingt die Behandlung als Attribut statt als Eigenschaft. Nützlich für Web C
 
 Solids JSX-Compiler verwendet eine einfache Heuristik für reaktives Verpacken und verzögerte Evaluierung von JSX-Ausdrücken. Erhält er einen Funktionsaufruf, ein Zugriff auf Props, oder JSX? Falls ja, werden diese in einen getter verpackt, wenn sie an native Elemente, Komponenten oder Effekte übergeben werden.
 
-Das zu wissen, hilft uns, die unnötige Behandlung von Dingen zu vermeiden, von denen wir wissen, dass sie sich nicht ändern werden, indem wir sie außerhalb des JSX addressieren. Eine einfache Variable wird nicht verpackt. Wir können dem Compiler auch manuell mitteilen, dass er einen Wert nicht verpacken soll, indem wir ihm einen einfachen Dekorator `/* @once */` voranstellen.
+Das zu wissen, hilft uns, die unnötige Behandlung von Dingen zu vermeiden, von denen wir wissen, dass sie sich nicht ändern werden, indem wir sie außerhalb des JSX adressieren. Eine einfache Variable wird nicht verpackt. Wir können dem Compiler auch manuell mitteilen, dass er einen Wert nicht verpacken soll, indem wir ihm einen einfachen Dekorator `/* @once */` voranstellen.
 
 ```jsx
 <MyComponent static={/*@once*/ state.wontUpdate} />

--- a/langs/de/guides/comparison.md
+++ b/langs/de/guides/comparison.md
@@ -1,6 +1,6 @@
 # Vergleich mit anderen Libraries
 
-Dieser Abschnitt wird nicht vollständig vorurteilsfrei sein, aber ich denke, dass es wichtig ist, zu verstehen, wo die Lösungsansatze von Solid stehen im Vergleich mit anderen Libraries. Dabei geht es nicht um Geschwindigkeit. Für einen abschließenden Blick auf Performance möge man einen Blick auf den [JS Framework Benchmark](https://github.com/krausest/js-framework-benchmark) werfen.
+Dieser Abschnitt wird nicht vollständig vorurteilsfrei sein, aber ich denke, dass es wichtig ist, zu verstehen, wo die Lösungsansätze von Solid stehen im Vergleich mit anderen Libraries. Dabei geht es nicht um Geschwindigkeit. Für einen abschließenden Blick auf Performance möge man einen Blick auf den [JS Framework Benchmark](https://github.com/krausest/js-framework-benchmark) werfen.
 
 ## React
 
@@ -10,7 +10,7 @@ Jedenfalls, so sehr Solid auch mit der Design-Philosophie von React übereinstim
 
 #### Migrationshilfe:
 
-Solids Aktualisierungsmethode ist ganz anders als die von React, oder als React + MobX. Statt an Funktionale Komponenten als Render-Funktion zu denken, denke man an einen `constructor`. Man sollte sich vor Destructuring oder verfrühtem Zugriff auf Props in Acht nehmen, durch die man die Reaktivität verlieren kann. Solids Primitiven haben keine Beschränkungen wie die Hooks-Regeln, also kann man sie ganz nach Belieben einsetzen. Man braucht keine keys bei Listen, um ein korrektes Verhalten zu ermöglichen. Zuguterletzt gibt es kein VDOM, also ergeben imperative VDOM APIs wie `React.Children` und `React.cloneElement` keinen Sinn. Ich ermutige gern dazu, unterschiedliche Wege zur Lösung von Problemen zu finden, die diese auf deklarative Weise nutzen.
+Solids Aktualisierungsmethode ist ganz anders als die von React, oder als React + MobX. Statt an funktionale Komponenten als Render-Funktion zu denken, denke man an einen `constructor`. Man sollte sich vor Destructuring oder verfrühtem Zugriff auf Props in Acht nehmen, durch die man die Reaktivität verlieren kann. Solids Primitiven haben keine Beschränkungen wie die Hooks-Regeln, also kann man sie ganz nach Belieben einsetzen. Man braucht keine keys bei Listen, um ein korrektes Verhalten zu ermöglichen. Zu guter Letzt gibt es kein VDOM, also ergeben imperative VDOM APIs wie `React.Children` und `React.cloneElement` keinen Sinn. Ich ermutige gern dazu, unterschiedliche Wege zur Lösung von Problemen zu finden, die diese auf deklarative Weise nutzen.
 
 ## Vue
 
@@ -24,7 +24,7 @@ Als eine andere moderne reaktive Library sollte die Migration von Vue 3 ein gewo
 
 ## Svelte
 
-Svelte hat Pionierarbeit bei den vorkompilierten Frameworks geleistet, das Solid ebenfalls zu einem gewissen Grad verwendet. Beide Libraries sind wirklich reaktiv und können sehr kleine Code-Bündel erzeugen, obwohl Svelte hierbei der Gewinner für kleine Demos ist. Solid braucht etwas mehr Explizitheit der Deklarationen, weil es weniger auf implizite Analyse durch den Kompiler setzt, was aber ein Teil dessen ist, was Solid seine überlegene Geschwindigkeit verleiht. Solid macht mehr während der Laufzeit, was bei größeren Anwendungen besser skaliert. Solid's realistische Demo-Anwendung ist 25% kleiner als die gleiche in Svelte.
+Svelte hat Pionierarbeit bei den vorkompilierten Frameworks geleistet, das Solid ebenfalls zu einem gewissen Grad verwendet. Beide Libraries sind wirklich reaktiv und können sehr kleine Code-Bündel erzeugen, obwohl Svelte hierbei der Gewinner für kleine Demos ist. Solid braucht etwas mehr Explizitheit der Deklarationen, weil es weniger auf implizite Analyse durch den Compiler setzt, was aber ein Teil dessen ist, was Solid seine überlegene Geschwindigkeit verleiht. Solid macht mehr während der Laufzeit, was bei größeren Anwendungen besser skaliert. Solid's realistische Demo-Anwendung ist 25 % kleiner als die gleiche in Svelte.
 
 Beide libraries versuchen, den Entwicklern zu helfen, weniger Code zu schreiben, aber die Herangehensweise ist vollkommen unterschiedlich. Svelte 3 konzentriert sich auf die Optimierung der Einfachheit im Umgang mit lokalen Änderungen, einfache Objekt-Interaktion und bidirektionales Data-Binding. Im Gegensatz dazu fokussiert sich Solid auf den Datenfluss, indem absichtlich CQRS und Unveränderlichkeit der Interfaces verwendet wird. Mit funktionaler Template-Berechnung erlaubt Solid in vielen Fällen den Entwicklern, noch weniger Code zu schreiben als Svelte, obwohl Sveltes Template-Syntax definitiv kürzer ist.
 
@@ -38,7 +38,7 @@ Diese Library verdankt ihre Existenz Knockout. Die ursprüngliche Motivation bes
 
 Knockouts bindings sind nur Strings in HTML, die während der Laufzeit durchlaufen werden. Sie hängen ab von geklontem Kontext ($parent usw...). Solid hingegen nutzt JSX oder Tagged Template Literals für das Templating für eine JS-gebundene API.
 
-Der größte Unterschied ist vermutlich Solids Herangehensweise, Änderunngen zu staffeln, was deren Gleichzeitigkeit gewährleistet, während Knockout mit deferUpdates eine verzögerte Micro-Task-Warteschlange hat.
+Der größte Unterschied ist vermutlich Solids Herangehensweise, Änderungen zu staffeln, was deren Gleichzeitigkeit gewährleistet, während Knockout mit deferUpdates eine verzögerte Micro-Task-Warteschlange hat.
 
 #### Migrationshilfe:
 
@@ -48,11 +48,11 @@ Wenn du an Knockout gewohnt bist, werden dir Solids Primitiven seltsam vorkommen
 
 Diese Libraries sind unglaublich ähnlich mit und hatten einigen Einfluss auf Solid. Vor allem, dass der von Solid kompilierte Code eine sehr ähnliche Methode verwendet, um das DOM zu rendern. Template-Elemente zu klonen und Kommentar-Platzhalter zu verwenden ist eine Gemeinsamkeit zwischen Solid und diesen Libraries.
 
-Der größte Unterschied ist, dass während diese Libraries kein virtuelles DOM verwendet, rendern sie wie dieses auch von oben nach unten, was es erfordert, die Komponenten zu partitionieren, um die Dinge vernünftig zu halten. Im Gegensatz dazu verwendet Solid eine feingranulare Reaktivität, um nur die Dinge zu ändern, die sich auch tatsächlich ändern sollen und damit diese Technik nur für das initiale Rendern benötigt. Diese Herangehensweise Diese Herangehensweise profitiert von der anfänglichen Geschwindigkeit, die nur nativem DOM zur Verfügung steht und hat gleichzeitig den performantesten Weg, Änderungen vorzunehmen.
+Der größte Unterschied ist, dass während diese Libraries kein virtuelles DOM verwendet, rendern sie wie dieses auch von oben nach unten, was es erfordert, die Komponenten zu partitionieren, um die Dinge vernünftig zu halten. Im Gegensatz dazu verwendet Solid eine feingranulare Reaktivität, um nur die Dinge zu ändern, die sich auch tatsächlich ändern sollen und damit diese Technik nur für das initiale Rendern benötigt. Diese Herangehensweise profitiert von der anfänglichen Geschwindigkeit, die nur nativem DOM zur Verfügung steht und hat gleichzeitig den performantesten Weg, Änderungen vorzunehmen.
 
 #### Migrationshilfe:
 
-Diese Libraries sind ziemlich minimal und es ist leicht, darauf aufzubauen. Allerdings sollte man bedenken, dass `<MyComp/>` nicht nur ein HTMLElement (Array oder Funktion) ist. Man sollte versuchen, die Dinge im JSX-Template zu behalten. Hoisting funktioniert meistenteils, aber es ist am Besten, dies als eine render-Library zu behandeln und nicht als HTMLElement-Fabrik.
+Diese Libraries sind ziemlich minimal und es ist leicht, darauf aufzubauen. Allerdings sollte man bedenken, dass `<MyComp/>` nicht nur ein HTMLElement (Array oder Funktion) ist. Man sollte versuchen, die Dinge im JSX-Template zu behalten. Hoisting funktioniert meistenteils, aber es ist am besten, dies als eine render-Library zu behandeln und nicht als HTMLElement-Fabrik.
 
 ## S.js
 

--- a/langs/de/guides/faq.md
+++ b/langs/de/guides/faq.md
@@ -2,9 +2,9 @@
 
 ### 1. JSX ohne ein VDOM? Ist das Vapourware? Ich habe prominente Stimmen wie die der Autoren anderer Frameworks sagen gehört, dies sei nicht möglich.
 
-Es ist möglich, wenn man nicht das Aktualisierungsmodell von React hat. JSX ist eine Template-Domain-spezifische-Sprache wie jede andere. Nur eine, die gewisser Weise flexibler ist. Willkührlichen JavaScript-Code einzufügen kann teilweise eine Herausforderung sein, was aber nicht anders ist als etwa die Unterstützung von Spread-Operatoren. Also nein, das ist keine Vapourware, sondern ein Ansatz, der erwiesenermaßen der Performanteste ist.
+Es ist möglich, wenn man nicht das Aktualisierungsmodell von React hat. JSX ist eine Template-Domain-spezifische-Sprache wie jede andere. Nur eine, die gewisser Weise flexibler ist. Willkürlichen JavaScript-Code einzufügen kann teilweise eine Herausforderung sein, was aber nicht anders ist als etwa die Unterstützung von Spread-Operatoren. Also nein, das ist keine Vapourware, sondern ein Ansatz, der erwiesenermaßen der Performanteste ist.
 
-Der wahre Vorteil kommt aus der Erweiterbarkeit. Der Kompiler arbeitet für einen, indem er optimale native DOM-Aktualisierungen gibt, man aber die Freiheit von Libraries wie React hat, Komponenten mit Techniken wie Render Props und Komponenten höherer Ordnung an der Seite reaktiver "Hooks" zu schreiben. Magst du nicht, wie der Kontrollfluss von Solid arbeitet? Schreib' deinen eigenen.
+Der wahre Vorteil kommt aus der Erweiterbarkeit. Der Compiler arbeitet für einen, indem er optimale native DOM-Aktualisierungen gibt, man aber die Freiheit von Libraries wie React hat, Komponenten mit Techniken wie Render Props und Komponenten höherer Ordnung an der Seite reaktiver "Hooks" zu schreiben. Magst du nicht, wie der Kontrollfluss von Solid arbeitet? Schreib' deinen eigenen.
 
 ### 2. Wie ist Solid so performant?
 
@@ -20,7 +20,7 @@ Dies sind derzeit einzigartige Techniken in einer Kombination, die Solid einen V
 
 Nein, und wahrscheinlich wird es das nie geben. Während die APIs ähnlich sind und man Komponenten oft mit wenigen Änderungen übertragen kann, ist das Aktualisierungs-Modell fundamental unterschiedlich. React-Komponenten werden wieder und wieder gerendert, so dass Code außerhalb der Hooks sehr anders funktioniert. Die Closures- und Hook-Regeln sind in Solid unnötig, erlauben aber auch Anwendungsweisen, die hier nicht funktionieren.
 
-Vue-compat wäre andererseits machbar. Allerdings gibt es derzeit nocht keine Pläne zur Umsetzung.
+Vue-compat wäre andererseits machbar. Allerdings gibt es derzeit noch keine Pläne zur Umsetzung.
 
 ### 4. Warum funktioniert Destructuring nicht? Ich habe festgestellt, dass ich das beheben kann, indem ich meine ganze Komponente in eine Funktion verpacke.
 
@@ -38,7 +38,7 @@ Man sollte Daten eher anhand deren Verhalten zusammenfassen als anhand der Lifec
 
 Nein. Keinen Schritt weiter. Wir nutzen JSX auf die gleiche Art wie Svelte seine Templates benutzt, um optimierte DOM-Instruktionen zu erstellen. Die Tagged Template Literal und HyperScript-Lösungen sind auf ihre eigene Art beeindruckend, aber solange es keinen guten Grund gibt wie etwa die Anforderung, dass nicht kompiliert werden darf, sind sie in jeder Hinsicht schlechter. Größere Bundles, langsamere Performance und die Notwendigkeit, Werte manuell zu schachteln.
 
-Es ist gut, Optionen zu haben, aber Solid's JSX ist wirklich die beste Lösung hier. Eine Template-DSK könnte auch toll sein, obwohl sie restriktiver wäre, aber JSX gibt uns so viel kostenlos. TypeScript, existierende Parser, Syntax Highlighting, TypeScript, Prettiert, Autovervollständigung und nicht zuletzt TypeScript.
+Es ist gut, Optionen zu haben, aber Solid's JSX ist wirklich die beste Lösung hier. Eine Template-DSK könnte auch toll sein, obwohl sie restriktiver wäre, aber JSX gibt uns so viel kostenlos. TypeScript, existierende Parser, Syntax Highlighting, TypeScript, Prettier, Autovervollständigung und nicht zuletzt TypeScript.
 
 Andere Libraries haben Unterstützung für diese Features anderweitig hinzugefügt, aber das war ein enormer Aufwand und ist immer noch unperfekt und ein konstanter Wartungsaufwand. Hier nehme ich einen pragmatischen Standpunkt ein.
 
@@ -50,13 +50,13 @@ So gern wir die beiden auch in eine einzelne API verschmelzen würden, kann man 
 
 ### 8. Warum kann ich nicht einfach einen Wert in Solids Store zuweisen, wie ich es in Vue, Svelte oder MobX kann? Wo ist das bidirektionale Data-Binding?
 
-Reaktivität ist ein machtvolles Werkzeug, aber auch ein gefährliches. MobX weiß das und hat den strikten Modus und Actions eingeführt, um zu beschränken, wann und wo Aktualisierungen passieren. In Solid, welches mit ganzen Komponentenstrukturen voll Daten arbeitet, wurde es klar, dass wir etwas von React lernen können. Man muss nicht unbedingt unveränderlich sein, so lange man die gleichen Vereinbarungen trifft.
+Reaktivität ist ein machtvolles Werkzeug, aber auch ein gefährliches. MobX weiß das und hat den strikten Modus und Actions eingeführt, um zu beschränken, wann und wo Aktualisierungen passieren. In Solid, welches mit ganzen Komponentenstrukturen voll Daten arbeitet, wurde es klar, dass wir etwas von React lernen können. Man muss nicht unbedingt unveränderlich sein, solange man die gleichen Vereinbarungen trifft.
 
-In der Lage zu sein, den State zu aktualisieren ist wohl weit weniger wichtig als die Entscheidung, den State weiterzugeben. Die Möglichkeit, ihn zu unterteilen, ist wichtiig und nur möglich, wenn Lesezugriffe unveränderlich sind. Wir müssen auch nicht die Kosten der Unveränderlichkeit aufbringen, wenn wir trotzdem granular aktualisieren können. Glücklicherweise gibt es reichlich Beispiele, wie man das macht, wie ImmutableJS und Immer. Ironischerweise agiert Solid meistens wie ein umgekehrtes Immer mit seinen veränderbaren Interna und unveränderbaren Schnittstellen.
+In der Lage zu sein, den State zu aktualisieren ist wohl weit weniger wichtig als die Entscheidung, den State weiterzugeben. Die Möglichkeit, ihn zu unterteilen, ist wichtig und nur möglich, wenn Lesezugriffe unveränderlich sind. Wir müssen auch nicht die Kosten der Unveränderlichkeit aufbringen, wenn wir trotzdem granular aktualisieren können. Glücklicherweise gibt es reichlich Beispiele, wie man das macht, wie ImmutableJS und Immer. Ironischerweise agiert Solid meistens wie ein umgekehrtes Immer mit seinen veränderbaren Interna und unveränderbaren Schnittstellen.
 
 ### 9. Kann ich nur die Reaktivität von Solid ohne den Rest verwenden?
 
-Natürlich. Obwohl es noch kein einzelnes Paket gibt, ist es einfach, Solid ohne den Kompiler zu installieren und nur die reaktiven Primitiven zu verwenden. Eine der Vorteile der granularen Reaktivität ist, dass sie Library-agnostisch ist. In dieser Hinsicht funktioniert nahezu jede reaktive Library auf die gleiche Weise. Das ist die ursprüngliche Inspiration hinter [Solid](https://github.com/solidjs/solid) und der darunterliegenden [DOM Expressions library](https://github.com/ryansolid/dom-expressions), um einen Renderer direkt aus dem reaktiven System zu machen.
+Natürlich. Obwohl es noch kein einzelnes Paket gibt, ist es einfach, Solid ohne den Compiler zu installieren und nur die reaktiven Primitiven zu verwenden. Eine der Vorteile der granularen Reaktivität ist, dass sie Library-agnostisch ist. In dieser Hinsicht funktioniert nahezu jede reaktive Library auf die gleiche Weise. Das ist die ursprüngliche Inspiration hinter [Solid](https://github.com/solidjs/solid) und der darunterliegenden [DOM Expressions library](https://github.com/ryansolid/dom-expressions), um einen Renderer direkt aus dem reaktiven System zu machen.
 
 Um ein paar Libraries zum Probieren aufzulisten: [Solid](https://github.com/solidjs/solid), [MobX](https://github.com/mobxjs/mobx), [Knockout](https://github.com/knockout/knockout), [Svelte](https://github.com/sveltejs/svelte), [S.js](https://github.com/adamhaile/S), [CellX](https://github.com/Riim/cellx), [Derivable](https://github.com/ds300/derivablejs), [Sinuous](https://github.com/luwes/sinuous), und neuerdings sogar [Vue](https://github.com/vuejs/vue). Es gehört mehr zu einer reaktiven Library als sie an einen Renderer zu hängen wie zum Beispiel [lit-html](https://github.com/Polymer/lit-html), aber dies ist trotzdem eine gute Möglichkeit, sich eine Vorstellung zu verschaffen.
 

--- a/langs/de/guides/reactivity.md
+++ b/langs/de/guides/reactivity.md
@@ -4,7 +4,7 @@ Die Datenverwaltung in Solid baut auf einer Reihe von flexiblen reaktiven Primit
 
 Solids Primitiven kommen in der Form von `create`-Aufrufen, die häufig Tupel zurückgeben, deren erstes Element generell den Lese- und das zweite den Schreibzugriff ermöglicht. Normalerweise benennt man den lesbaren Teil beim Namen der Primitive.
 
-Hier ist ein einfacher automatisch hochlaufender Zähler, der durch das Schreiben des `count`-Signals aktualisiert wird.
+Hier ist ein einfacher automatisch hoch laufender Zähler, der durch das Schreiben des `count`-Signals aktualisiert wird.
 
 ```jsx
 import { createSignal, onCleanup } from "solid-js";
@@ -37,7 +37,7 @@ Effekte sind Funktionen, in die Lesezugriffe auf Signale verpackt werden und die
 createEffect(() => console.log("The latest count is", count()));
 ```
 
-Memos sind zwischengespeicherte von Signalen abgeleitete Werte. Sie haben die Eigenschaften sowohl von Signalen als auch von Effekten. Sie verfolgen die Signale, auf denen sie basieren und werden neu ausgeführt wenn sich deren Werte ändern und sind selbst verfolgbare Signale.
+Memos sind zwischengespeicherte von Signalen abgeleitete Werte. Sie haben die Eigenschaften sowohl von Signalen als auch von Effekten. Sie verfolgen die Signale, auf denen sie basieren und werden neu ausgeführt, wenn sich deren Werte ändern und sind selbst verfolgbare Signale.
 
 ```js
 const fullName = createMemo(() => `${firstName()} ${lastName()}`);
@@ -74,7 +74,7 @@ function createSignal(value) {
 
 Jetzt wissen wir bei jeder Aktualisierung, welche Effekte neu aufgerufen werden müssen. Einfach, aber effektiv. Die tatsächliche Implementierung ist wesentlich komplizierter, aber das ist die Quintessenz dessen, was passiert.
 
-Für ein detailiierteres Verständnis, wie Reaktivität funktioniert, gibt es diese nützlichen Artikel:
+Für ein detaillierteres Verständnis, wie Reaktivität funktioniert, gibt es diese nützlichen Artikel:
 
 [A Hands-on Introduction to Fine-Grained Reactivity](https://dev.to/ryansolid/a-hands-on-introduction-to-fine-grained-reactivity-3ndf)
 

--- a/langs/de/guides/rendering.md
+++ b/langs/de/guides/rendering.md
@@ -4,11 +4,11 @@ Solid unterstützt Templating in 3 Formen: JSX, Tagged Template Literals und Sol
 
 ## JSX kompilieren
 
-Rendering beinhaltet das Vorkomplieren von JSX-Templates zu optimiertem nativen JS-Code. Der JSX-Code erzeugt:
+Rendering beinhaltet das Vorkompilieren von JSX-Templates zu optimiertem nativen JS-Code. Der JSX-Code erzeugt:
 
 - DOM Templates, die bei der Erstellung der Instanz geklont werden
 - Eine Reihe von Referenzdeklarationen die nur firstChild und nextSibling verwenden
-- Feingranulare Berechnngen, um die so erzeugten Elemente zu aktualisieren.
+- Feingranulare Berechnungen, um die so erzeugten Elemente zu aktualisieren.
 
 Diese Herangehensweise ist einerseits performanter und erzeugt andererseits auch weniger Code als jedes Element einzeln eins nach dem anderen mit document.createElement zu erzeugen.
 
@@ -43,7 +43,7 @@ render(() => <App />, document.getElementById("main"));
 
 ## Komponenten
 
-Komponenten sind in Solid einfach Pascal-case-benannte (am Anfang groß geschrieben) Funktionen. Ihr erster Parameter ist ein props-Objekt und sie geben echte DOM-Nodes aus.
+Komponenten sind in Solid einfach Pascal-case-benannte (am Anfang großgeschrieben) Funktionen. Ihr erster Parameter ist ein props-Objekt und sie geben echte DOM-Nodes aus.
 
 ```jsx
 const Parent = () => (
@@ -207,7 +207,7 @@ const BasicComponent = (props) => {
 };
 ```
 
-Solids Komponenten machen einen wesentlicher Teil von dessen Performance aus. Solids Herangehensweise, Komponenten "verschwinden" zu lassen wird durch verzögerte Prop-Berechnung möglich. Statt sofort alle Prop-Ausdrücke zu berechnen und die Werte weiterzugeben, wird die Ausführung verzögert, bis auf die Prop im Kind-Element zugegriffen wird. Damit wird die Ausführung bis zum letzten möglichen Moment verzögert, typischerweise direkt bei den DOM-Einbindungen, was die Performance maximiert. Das sorgt für flache Hierarchien und entfernt die Notwendigkeit, einen Komponenten-Baum zu behandeln.
+Solids Komponenten machen einen wesentlichen Teil von dessen Performance aus. Solids Herangehensweise, Komponenten "verschwinden" zu lassen wird durch verzögerte Prop-Berechnung möglich. Statt sofort alle Prop-Ausdrücke zu berechnen und die Werte weiterzugeben, wird die Ausführung verzögert, bis auf die Prop im Kind-Element zugegriffen wird. Damit wird die Ausführung bis zum letzten möglichen Moment verzögert, typischerweise direkt bei den DOM-Einbindungen, was die Performance maximiert. Das sorgt für flache Hierarchien und entfernt die Notwendigkeit, einen Komponenten-Baum zu behandeln.
 
 ```jsx
 <Component prop1="static" prop2={state.dynamic} />;

--- a/langs/de/guides/server.md
+++ b/langs/de/guides/server.md
@@ -38,7 +38,7 @@ const { readable, writable } = new TransformStream();
 pipeToWritable(() => <App />, writable);
 ```
 
-Bequemerweise exportiert `solid-js/web` ein `isServer`-Flag. Das ist nützlich, da viele JS-Bündler in der Lage sind, unbenutzten Code innerhalb von Abfragen dieses Flags mit Tree Shaking zu entfernen und imports, die nur von diesem Code genutzt werden, aus dem Client-Code herauszulassen.
+Bequemer weise exportiert `solid-js/web` ein `isServer`-Flag. Das ist nützlich, da viele JS-Bundler in der Lage sind, unbenutzten Code innerhalb von Abfragen dieses Flags mit Tree Shaking zu entfernen und imports, die nur von diesem Code genutzt werden, aus dem Client-Code herauszulassen.
 
 ```jsx
 import { isServer } from "solid-js/web";
@@ -92,7 +92,7 @@ const App = () => {
 };
 ```
 
-Wenn man vom document aus hydriert, kann das Einfügen von Ressourcen, die noch nicht verfübbar sind, Dinge durcheinander bringen. Solid hat dafür eine `<NoHydration>`-Komponente, deren Kinder ganz normal auf dem Server funktionieren, aber nicht im Browser hydriert werden.
+Wenn man vom document aus hydriert, kann das Einfügen von Ressourcen, die noch nicht verfügbar sind, Dinge durcheinander bringen. Solid hat dafür eine `<NoHydration>`-Komponente, deren Kinder ganz normal auf dem Server funktionieren, aber nicht im Browser hydriert werden.
 
 ```jsx
 <NoHydration>
@@ -132,4 +132,4 @@ Zwischenzeitlich hat die Arbeit an einem neuen Starter begonnen, [SolidStart](ht
 
 ## Den Anfang mit statischer Seitengenerierung machen
 
-[solid-ssr](https://github.com/solidjs/solid/blob/main/packages/solid-ssr) hat auch ein Werkzeugt, um statische oder vorgerenderte Seiten zu erzeugen. In der README-Daten finden sich weitere Informationen dazu.
+[solid-ssr](https://github.com/solidjs/solid/blob/main/packages/solid-ssr) hat auch ein Werkzeug, um statische oder vorgerenderte Seiten zu erzeugen. In der README-Daten finden sich weitere Informationen dazu.

--- a/langs/de/tutorials/introduction_derived/lesson.md
+++ b/langs/de/tutorials/introduction_derived/lesson.md
@@ -1,6 +1,6 @@
 Wir haben gesehen, dass jedes Mal, wenn wir ein Signal in JSX auslesen, es automatisch die Oberfläche aktualisiert, wenn sich das Signal verändert. Aber die Komponenten-Funktionen selbst laufen nur ein Mal.
 
-Wir können neue Ausdrücke erzeugen, die auf anderen Signalen basieren, indem wir sie in eine Funktion schachteln. Eine Funktion, die ein Signal aufruft, wird damit effektiv selbst ein Signal: wenn die darin enthaltenen Signale aktualsiert werden, wird es von dessen Nutzern aktualisiert.
+Wir können neue Ausdrücke erzeugen, die auf anderen Signalen basieren, indem wir sie in eine Funktion schachteln. Eine Funktion, die ein Signal aufruft, wird damit effektiv selbst ein Signal: wenn die darin enthaltenen Signale aktualisiert werden, wird es von dessen Nutzern aktualisiert.
 
 Lass uns unseren Counter aktualisieren, in dem wir eine `doubleCount`-Funktion hinzufügen:
 


### PR DESCRIPTION
Fixed a few typos in the german translations