### PR TITLE
Fix tutorial links

### DIFF
--- a/langs/en/guides/getting-started.md
+++ b/langs/en/guides/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-**We're working on new docs.** You can check out our new beginner tutorial [here](https://docs.solidjs.com/tutorials/getting-started-with-solid/), and join our efforts on [Discord!](http://discord.com/invite/solidjs)
+**We're working on new docs.** You can check out our new beginner tutorial [here](https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/), and join our efforts on [Discord!](http://discord.com/invite/solidjs)
 
 ## See Solid
 

--- a/langs/en/tutorials/introduction_basics/lesson.md
+++ b/langs/en/tutorials/introduction_basics/lesson.md
@@ -2,7 +2,7 @@
 
 This interactive guide will walk you through Solid's main features. You can also refer to the API and guides to learn more about how Solid works.
 
-You can also check out our new beginner tutorial (work-in-progress!) [here](https://docs.solidjs.com/tutorials/getting-started-with-solid/).
+You can also check out our new beginner tutorial (work-in-progress!) [here](https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/).
 
 # What is Solid?
 


### PR DESCRIPTION
Whilst looking through the docs I noticed that both of the links to the new tutorial 404'd.