### PR TITLE
docs: Fix getting started URL

### DIFF
--- a/langs/en/guides/getting-started.md
+++ b/langs/en/guides/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-**We're working on new docs.** You can check out our new beginner tutorial [here](https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/), and join our efforts on [Discord!](http://discord.com/invite/solidjs)
+**We're working on new docs.** You can check out our new beginner tutorial [here](https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/welcome), and join our efforts on [Discord!](http://discord.com/invite/solidjs)
 
 ## See Solid
 

--- a/langs/en/tutorials/introduction_basics/lesson.md
+++ b/langs/en/tutorials/introduction_basics/lesson.md
@@ -2,7 +2,7 @@
 
 This interactive guide will walk you through Solid's main features. You can also refer to the API and guides to learn more about how Solid works.
 
-You can also check out our new beginner tutorial (work-in-progress!) [here](https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/).
+You can also check out our new beginner tutorial (work-in-progress!) [here](https://docs.solidjs.com/guides/tutorials/getting-started-with-solid/welcome).
 
 # What is Solid?
 


### PR DESCRIPTION
## What does this PR?
Introduce a change to the getting started URL on the guide page for redirecting to the correct URL (/welcome) and avoid the next page
<img width="1389" alt="Screen Shot 2022-12-19 at 18 53 59" src="https://user-images.githubusercontent.com/9642510/208531483-d2d30fff-1b04-426e-95cd-ad0b9128ed2d.png">
