### PR TITLE
Document workaround for TS error when updating stores

### DIFF
--- a/langs/en/api/api.md
+++ b/langs/en/api/api.md
@@ -1026,7 +1026,7 @@ fullName = createMemo(() => `${state.user.firstName} ${state.user.lastName}`);
 
 ### Updating Stores
 
-Changes can take the form of function that passes previous state and returns new state or a value. Objects are always shallowly merged. Set values to `undefined` to delete them from the Store. In Typescript, you can delete a value by using a non-null assertion, like `undefined!`.
+Changes can take the form of function that passes previous state and returns new state or a value. Objects are always shallowly merged. Set values to `undefined` to delete them from the Store. In TypeScript, you can delete a value by using a non-null assertion, like `undefined!`.
 
 ```js
 const [state, setState] = createStore({

--- a/langs/en/api/api.md
+++ b/langs/en/api/api.md
@@ -1026,7 +1026,7 @@ fullName = createMemo(() => `${state.user.firstName} ${state.user.lastName}`);
 
 ### Updating Stores
 
-Changes can take the form of function that passes previous state and returns new state or a value. Objects are always shallowly merged. Set values to `undefined` to delete them from the Store.
+Changes can take the form of function that passes previous state and returns new state or a value. Objects are always shallowly merged. Set values to `undefined` to delete them from the Store. In Typescript, you can delete a value by using a non-null assertion, like `undefined!`.
 
 ```js
 const [state, setState] = createStore({


### PR DESCRIPTION
When updating a store, TypeScript complains that `undefined` is not the same type as the value the store holds.

The workaround is to use a non-null assertion operator. I suspect most developers have never asserted `undefined` as non-null before and wouldn't think to do that, so this PR documents that as the solution.