### PR TITLE
Fix typo in the flow_switch lesson

### DIFF
--- a/langs/en/tutorials/flow_switch/lesson.md
+++ b/langs/en/tutorials/flow_switch/lesson.md
@@ -1,6 +1,6 @@
 Sometimes you need to deal with conditionals with more than 2 mutual exclusive outcomes. For this case, we have the `<Switch>` and `<Match>` components modeled roughly after JavaScript's `switch`/`case`.
 
-It will try in order to match each condition, stopping to render the first that evaluates to true. Failing all of them, it will render the the fallback.
+It will try in order to match each condition, stopping to render the first that evaluates to true. Failing all of them, it will render the fallback.
 
 In the example, we can replace our nested `<Show>` components with this:
 


### PR DESCRIPTION
Just noticed a new doc is under development but I decided to open this anyway :)

### Changes
- Remove an additional unnecessary `the`.