### PR TITLE
Makes more obvious what `Show` is doing.

### DIFF
--- a/langs/en/tutorials/async_suspense/lesson.md
+++ b/langs/en/tutorials/async_suspense/lesson.md
@@ -22,7 +22,7 @@ It's important to note that it's the read of an async derived value that trigger
 ```jsx
 function Deferred(props) {
   const [resume, setResume] = createSignal(false);
-  setTimeout(() => setResume(true), 0);
+  setTimeout(() => setResume(true), 1000);
 
   return <Show when={resume()}>{props.children}</Show>;
 }


### PR DESCRIPTION
The timeout seems to be trying to show that the component will render async by queueing it to the end of the event loop. Maybe a better way to communicate is to make it render after a time.