### PR TITLE
docs(ja): typescript guide wrong markup and missing in directory.json

### DIFF
--- a/langs/ja/guides/directory.json
+++ b/langs/ja/guides/directory.json
@@ -20,6 +20,11 @@
     "description": "Solid のサーバーサイド機能についての説明"
   },
   {
+    "resource": "typescript",
+    "title": "TypeScript",
+    "description": "Solid を TypeScript で使用するためのヒント"
+  },
+  {
     "resource": "testing",
     "title": "Solid のテスト",
     "description": "Solid アプリのテスト方法"

--- a/langs/ja/guides/typescript.md
+++ b/langs/ja/guides/typescript.md
@@ -1,8 +1,3 @@
----
-title: TypeScript
-description: Solid を TypeScript で使用するためのヒント 
-sort: 3
----
 # TypeScript
 
 Solid は、TypeScript で簡単に使用できるよう設計されています。


### PR DESCRIPTION
Wrong markup
---
<img width="632" alt="スクリーンショット 2023-03-03 12 19 05" src="https://user-images.githubusercontent.com/49431394/222623001-3dee4f54-67f4-47b2-b0e0-b2d827b5ec11.png">

