### PR TITLE
Updates for 1.7

### DIFF
--- a/langs/en/api/api.md
+++ b/langs/en/api/api.md
@@ -515,16 +515,6 @@ function onCleanup(fn: () => void): void;
 
 Registers a cleanup method that executes on disposal or recalculation of the current reactive scope. Can be used in any Component or Effect.
 
-## `onError`
-
-```ts
-import { onError } from "solid-js";
-
-function onError(fn: (err: any) => void): void;
-```
-
-Registers an error handler method that executes when child scope errors. Only the nearest scope error handlers execute. Rethrow to trigger up the line.
-
 # Reactive Utilities
 
 These helpers provide the ability to better schedule updates and control how reactivity is tracked.
@@ -583,6 +573,28 @@ setA("new"); // now it runs
 ```
 
 Please note that on `stores` and `mutable`, adding or removing a property from the parent object will trigger an effect. See [`createMutable`](#createMutable)
+
+## `catchError`
+**New in v1.7.0**
+
+```ts
+import { catchError } from "solid-js";
+
+function catchError<T>(tryFn: () => T, onError: (err: any) => void): T;
+```
+
+Wraps a `tryFn` with an error handler that fires if an error occurs below that point. Only the nearest scope error handlers execute. Rethrow to trigger up the line.
+
+## `onError`
+**Deprecated for catchError in v1.7**
+
+```ts
+import { onError } from "solid-js";
+
+function onError(fn: (err: any) => void): void;
+```
+
+Registers an error handler method that executes when child scope errors. Only the nearest scope error handlers execute. Rethrow to trigger up the line.
 
 ## `createRoot`
 
@@ -1896,8 +1908,8 @@ function Show<T>(props: {
   when: T | undefined | null | false;
   keyed: boolean;
   fallback?: JSX.Element;
-  children: JSX.Element | ((item: T) => JSX.Element);
-}): () => JSX.Element;
+  children: JSX.Element | ((item: () => T) => JSX.Element) | ((item: T) => JSX.Element);
+}): JSX.Element;
 ```
 
 The Show control flow is used to conditional render part of the view: it renders `children` when the `when` is truthy, an `fallback` otherwise. It is similar to the ternary operator (`when ? children : fallback`) but is ideal for templating JSX.
@@ -1905,6 +1917,14 @@ The Show control flow is used to conditional render part of the view: it renders
 ```jsx
 <Show when={state.count > 0} fallback={<div>Loading...</div>}>
   <div>My Content</div>
+</Show>
+```
+
+Show can also be used with a callback that returns a null asserted accessor. Remember to only use this accessor when the condition is true or it will throw.
+
+```jsx
+<Show when={state.user} fallback={<div>Loading...</div>}>
+  {(user) => <div>{user().firstName}</div>}
 </Show>
 ```
 

--- a/langs/en/guides/typescript.md
+++ b/langs/en/guides/typescript.md
@@ -338,7 +338,7 @@ could be any `DOMElement`.
 This is because `currentTarget` is the element that the
 event handler was attached to, so has a known type, whereas `target` is
 whatever the user interacted with that caused the event to bubble to or get
-captured by the event handler, which can be any DOM element.
+captured by the event handler, which can be any DOM element. One exception is Input and Focus Events when attached directly to `input` elements will have HTMLInputElement as a `target`.
 
 ## The ref Attribute
 
@@ -500,7 +500,7 @@ Here are two workarounds for this issue:
    return (
      <Show when={name()}>
        {(n) =>
-         <>Hello {n.replace(/\s+/g, '\xa0')}!</>
+         <>Hello {n().replace(/\s+/g, '\xa0')}!</>
        }
      </Show>
    );
@@ -508,13 +508,7 @@ Here are two workarounds for this issue:
 
    In this case, the typing of the `Show` component is clever enough to tell
    TypeScript that `n` is truthy, so it can't be `undefined` (or `null` or
-   `false`).
-
-   Note, however, that this form of `<Show>` forces the entirety of the 
-   children to render
-   from scratch every time `name()` changes, instead of doing this just when `name()` changes from a falsy to a truthy value.
-   This means that the children don't have the full benefits of fine-grained
-   reactivity (re-using unchanged parts and updating just what changed).
+   `false`). Remember this null asserted form will throw if accessed when the condition is no longer true.
 
 ## Special JSX Attributes and Directives
 


### PR DESCRIPTION
Added `catchError` and updated API docs and TypeScript guide around null asserted control flow.