### PR TITLE
docs (api -> createSiganl): fix the flaw in the example code

### DIFF
--- a/langs/en/api/api.md
+++ b/langs/en/api/api.md
@@ -132,7 +132,7 @@ const [depend, rerun] = createSignal(undefined, { equals: false });
 
 // define equality based on string length:
 const [myString, setMyString] = createSignal("string", {
-  equals: (newVal, oldVal) => newVal.length === oldVal.length,
+  equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
 setMyString("strung"); // considered equal to the last value and won't cause updates

--- a/langs/es/api/api.md
+++ b/langs/es/api/api.md
@@ -46,7 +46,7 @@ De forma predeterminada, cuando se llama al setter de una señal, las dependenci
 
 ```js
 const [miString, setMiString] = createSignal("string", {
-	equals: (newVal, oldVal) => newVal.length === oldVal.length,
+	equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
 setMyString("strung"); //es considerado igual al ultimo valor y no generará actualizaciones

--- a/langs/ja/api/api.md
+++ b/langs/ja/api/api.md
@@ -146,7 +146,7 @@ const [depend, rerun] = createSignal(undefined, { equals: false });
 
 // 文字列の長さに基づいて「等しいかどうか」を定義する:
 const [myString, setMyString] = createSignal("string", {
-  equals: (newVal, oldVal) => newVal.length === oldVal.length,
+  equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
 setMyString("strung"); // 最後の値と等しいと見なされ、更新は発生しません

--- a/langs/ko-kr/api/api.md
+++ b/langs/ko-kr/api/api.md
@@ -114,7 +114,7 @@ const [depend, rerun] = createSignal(undefined, { equals: false });
 
 // 문자열의 길이에 따라 동등성 비교 정의:
 const [myString, setMyString] = createSignal("string", {
-  equals: (newVal, oldVal) => newVal.length === oldVal.length,
+  equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
 setMyString("strung"); // 이전 값과 동일한 것으로 판단해 업데이트가 발생하지 않습니다.

--- a/langs/ru/api/api.md
+++ b/langs/ru/api/api.md
@@ -131,7 +131,7 @@ const [depend, rerun] = createSignal(undefined, { equals: false });
 
 // Равенство определяется длиной строк
 const [myString, setMyString] = createSignal("string", {
-  equals: (newVal, oldVal) => newVal.length === oldVal.length,
+  equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
 setMyString("strung"); // не вызовет обновления, поскольку будет рассматриваться равной (на основе длины строк)

--- a/langs/zh-cn/api/api.md
+++ b/langs/zh-cn/api/api.md
@@ -87,7 +87,7 @@ const [depend, rerun] = createSignal(undefined, { equals: false });
 
 // 根据字符串长度定义相等：
 const [myString, setMyString] = createSignal("string", {
-  equals: (newVal, oldVal) => newVal.length === oldVal.length,
+  equals: (oldVal, newVal) => newVal.length === oldVal.length,
 });
 
 setMyString("strung"); // 被认为等于最后一个值并且不会导致更新


### PR DESCRIPTION
## Description of Problem
The following example code in this page's documentation is **miswritten**. 
According to the definition of `equals`, the first formal parameter should be `oldVal` and the second formal parameter should be `newVal`.

```js
// ...
const [myString, setMyString] = createSignal("string", {
  equals: (newVal, oldVal) => newVal.length === oldVal.length
});
// ...
```

## Proposed Solution
```js
// ...
const [myString, setMyString] = createSignal("string", {
  equals: (oldVal, newVal) => newVal.length === oldVal.length
});
// ...
```
## Other Info
This modification has also been synchronized to the new documentation, [look here](https://github.com/solidjs/solid-docs-next/pull/264).