### PR TITLE
Use vite templates in starter guide

### DIFF
--- a/langs/de/guides/getting-started.md
+++ b/langs/de/guides/getting-started.md
@@ -7,7 +7,7 @@ Mit Abstand die einfachste Möglichkeit, in Solid einzusteigen, ist, es online a
 Alternativ kann man auch unsere einfachen [Vite](https://vitejs.dev/)-Vorlagen nutzen, indem man folgende Anweisungen ins Terminal eingibt:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i # oder yarn oder pnpm
 > npm run dev # oder yarn oder pnpm
@@ -16,7 +16,7 @@ Alternativ kann man auch unsere einfachen [Vite](https://vitejs.dev/)-Vorlagen n
 Oder für TypeScript:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # oder yarn oder pnpm
 > npm run dev # oder yarn oder pnpm

--- a/langs/en/guides/getting-started.md
+++ b/langs/en/guides/getting-started.md
@@ -15,7 +15,7 @@ By far the easiest way to get started with Solid is to try it online. Our REPL a
 Alternatively, you can use our [Vite templates](https://github.com/solidjs/templates) by running these commands in your terminal:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm
@@ -24,7 +24,7 @@ Alternatively, you can use our [Vite templates](https://github.com/solidjs/templ
 Or for TypeScript:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm

--- a/langs/id/guides/getting-started.md
+++ b/langs/id/guides/getting-started.md
@@ -7,7 +7,7 @@ Sejauh ini cara termudah untuk mulai menggunakan Solid adalah dengan mencobanya 
 Atau, kamu juga dapat menggunakan template-template [Vite](https://vitejs.dev/) sederhana kami dengan menjalankan perintah-perintah dibawah ini pada terminal kamu:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm
@@ -16,7 +16,7 @@ Atau, kamu juga dapat menggunakan template-template [Vite](https://vitejs.dev/) 
 Atau untuk pengguna TypeScript:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm

--- a/langs/it/guides/getting-started.md
+++ b/langs/it/guides/getting-started.md
@@ -16,7 +16,7 @@ Il modo migliore per imparare Solid è provarlo online. Il nostro REPL su https:
 In alternativa, puoi utilizzare i nostri semplici modelli [Vite](https://vitejs.dev/) eseguendo questi comandi nel tuo terminale:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd mia-app
 > npm i # o yarn o pnpm
 > npm run dev # o yarn o pnpm
@@ -25,7 +25,7 @@ In alternativa, puoi utilizzare i nostri semplici modelli [Vite](https://vitejs.
 O per TypeScript:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd mia-app
 > npm i # o yarn o pnpm
 > npm run dev # o fyarn o pnpm

--- a/langs/ja/guides/getting-started.md
+++ b/langs/ja/guides/getting-started.md
@@ -16,7 +16,7 @@ Solid を使い始める最も簡単な方法は、オンラインで試すこ�
 また、ターミナルで以下のコマンドを実行して、 [Vite テンプレート](https://github.com/solidjs/templates) を使用することもできます:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm
@@ -25,7 +25,7 @@ Solid を使い始める最も簡単な方法は、オンラインで試すこ�
 または TypeScript 向けに:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm

--- a/langs/ko-kr/guides/getting-started.md
+++ b/langs/ko-kr/guides/getting-started.md
@@ -16,7 +16,7 @@ Solid를 사용하기 위한 가장 쉬운 방법은 온라인으로 시도해 �
 또한, 터미널에서 다음 명령을 실행해서 간단한 [Vite 템플릿](https://github.com/solidjs/templates)을 사용할 수 있습니다:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm
@@ -25,7 +25,7 @@ Solid를 사용하기 위한 가장 쉬운 방법은 온라인으로 시도해 �
 타입스크립트를 사용하려면 다음과 같이 실행합니다:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm

--- a/langs/pt/guides/getting-started.md
+++ b/langs/pt/guides/getting-started.md
@@ -7,7 +7,7 @@ De longe, a maneira mais fácil de começar a usar o Solid é experimentá-lo on
 Como alternativa, você pode usar nossos modelos simples [Vite](https://vitejs.dev/) executando estes comandos em seu terminal:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i # ou yarn ou pnpm
 > npm run dev # ou yarn ou pnpm
@@ -16,7 +16,7 @@ Como alternativa, você pode usar nossos modelos simples [Vite](https://vitejs.d
 Ou para TypeScript:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # ou yarn ou pnpm
 > npm run dev # ou yarn ou pnpm

--- a/langs/ru/guides/getting-started.md
+++ b/langs/ru/guides/getting-started.md
@@ -7,7 +7,7 @@
 Кроме того, вы можете использовать наши простые [Vite](https://vitejs.dev/) шаблоны, выполнив следующие команды в своем терминале:
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i #  yarn/pnpm
 > npm run dev #  yarn/pnpm
@@ -16,7 +16,7 @@
 Или с поддержкой TypeScript:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # yarn/pnpm
 > npm run dev # yarn/pnpm

--- a/langs/zh-cn/guides/getting-started.md
+++ b/langs/zh-cn/guides/getting-started.md
@@ -16,7 +16,7 @@
 或者，您可以通过在终端中运行以下命令来使用我们的 [Vite 模板](https://github.com/solidjs/templates)：
 
 ```sh
-> npx degit solidjs/templates/js my-app
+> npm create vite@latest my-app -- --template solid
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm
@@ -25,7 +25,7 @@
 或者使用 TypeScript:
 
 ```sh
-> npx degit solidjs/templates/ts my-app
+> npm create vite@latest my-app -- --template solid-ts
 > cd my-app
 > npm i # or yarn or pnpm
 > npm run dev # or yarn or pnpm


### PR DESCRIPTION
The guide currently suggest to start a new project with:

`npx degit solidjs/templates/js my-app`

This replaces it with the official vite templates:

`npm create vite@latest my-app -- --template solid `

List of all official vite templates:
https://vitejs.dev/guide/#trying-vite-online