### PR TITLE
Fix link of `스프레드 구문`

### DIFF
--- a/langs/ko-kr/tutorials/flow_for/lesson.md
+++ b/langs/ko-kr/tutorials/flow_for/lesson.md
@@ -16,4 +16,4 @@
 
 인덱스는 상수가 아닌 _Signal_ 이라는 점에 유의해야 합니다. `<For>`는 "참조에 의해 키 지정" 되기 때문에, 렌더링하는 각 노드는 배열의 요소에 연결됩니다. 즉, 배열에 있는 요소가 삭제 및 재생성되는 대신 위치가 변경되면 연결된 노드도 같이 이동해 해당 인덱스가 변경됩니다.
 
-`each` prop은 배열 타입만 사용해야 하지만, [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from), [`Object.keys`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys), 또는 [스프레드 구문](`https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax`)과 같은 유틸리티를 사용해 iterable 객체를 배열로 바꿀 수 있습니다.
+`each` prop은 배열 타입만 사용해야 하지만, [`Array.from`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from), [`Object.keys`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys), 또는 [스프레드 구문](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)과 같은 유틸리티를 사용해 iterable 객체를 배열로 바꿀 수 있습니다.


### PR DESCRIPTION
Removed ` in link (ko-kr)
- https://www.solidjs.com/tutorial/flow_for

# as-is
... 또는 [스프레드 구문](`https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax`)과 같은 유틸리티를 사용해 iterable 객체를 배열로 바꿀 수 있습니다.
```md
... 또는 [스프레드 구문](`https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax`)과 같은 유틸리티를 사용해 iterable 객체를 배열로 바꿀 수 있습니다.
```

This link leads me to `https://www.solidjs.com/tutorial/%60https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax%60`

# to-be
... 또는 [스프레드 구문](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)과 같은 유틸리티를 사용해 iterable 객체를 배열로 바꿀 수 있습니다.
```md
... 또는 [스프레드 구문](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax)과 같은 유틸리티를 사용해 iterable 객체를 배열로 바꿀 수 있습니다.
```
