### PR TITLE
Fix indepth.dev links

### DIFF
--- a/langs/de/guides/reactivity.md
+++ b/langs/de/guides/reactivity.md
@@ -80,7 +80,7 @@ Für ein detaillierteres Verständnis, wie Reaktivität funktioniert, gibt es di
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Überlegungen
 

--- a/langs/en/guides/reactivity.md
+++ b/langs/en/guides/reactivity.md
@@ -80,7 +80,7 @@ For more detailed understanding of how Reactivity works these are useful article
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Considerations
 

--- a/langs/es/guides/reactivity.md
+++ b/langs/es/guides/reactivity.md
@@ -80,7 +80,7 @@ Para entender mas detalladamente como la Reactividad funciona, estos son unos ar
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Consideraciones
 

--- a/langs/fr/guides/reactivity.md
+++ b/langs/fr/guides/reactivity.md
@@ -80,7 +80,7 @@ Pour plus de détails au sujet de la Réactivité et de son fonctionnent, ces ar
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Considérations
 

--- a/langs/id/guides/reactivity.md
+++ b/langs/id/guides/reactivity.md
@@ -81,7 +81,7 @@ Untuk memahami lebih detail bagaimana Reaktifitas bekerja, berikut artikel-artik
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Hal yang perlu dipertimbangkan
 

--- a/langs/it/guides/reactivity.md
+++ b/langs/it/guides/reactivity.md
@@ -80,7 +80,7 @@ Per una comprensione più dettagliata di come funziona Reattività, questi sono 
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Considerazioni
 

--- a/langs/ja/guides/reactivity.md
+++ b/langs/ja/guides/reactivity.md
@@ -80,7 +80,7 @@ function createSignal(value) {
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## 考慮すべき点
 

--- a/langs/ko-kr/guides/reactivity.md
+++ b/langs/ko-kr/guides/reactivity.md
@@ -32,7 +32,7 @@ const [count, setCount] = createSignal(0);
 ```
 
 이펙트는 시그널 읽기를 래핑해서, 관련 시그널의 값이 변경될 때마다 재실행되는 함수입니다. 렌더링과 같은 사이드 이펙트를 생성하는데 유용합니다.
- 
+
 ```js
 createEffect(() => console.log("The latest count is", count()));
 ```
@@ -80,7 +80,7 @@ function createSignal(value) {
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## 고려 사항
 

--- a/langs/pt/guides/reactivity.md
+++ b/langs/pt/guides/reactivity.md
@@ -80,7 +80,7 @@ Para uma compreensão mais detalhada de como funciona a reatividade, estes são 
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Considerações
 

--- a/langs/ru/guides/reactivity.md
+++ b/langs/ru/guides/reactivity.md
@@ -80,7 +80,7 @@ function createSignal(value) {
 
 [Создание реактивной библиотеки с нуля](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: От реактивности до рендеринга](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: От реактивности до рендеринга](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## Особенности реактивности Solid
 

--- a/langs/zh-cn/guides/reactivity.md
+++ b/langs/zh-cn/guides/reactivity.md
@@ -80,7 +80,7 @@ function createSignal(value) {
 
 [Building a Reactive Library from Scratch](https://dev.to/ryansolid/building-a-reactive-library-from-scratch-1i0p)
 
-[SolidJS: Reactivity to Rendering](https://indepth.dev/posts/1289/solidjs-reactivity-to-rendering)
+[SolidJS: Reactivity to Rendering](https://angularindepth.com/posts/1289/solidjs-reactivity-to-rendering)
 
 ## 注意事项
 


### PR DESCRIPTION
Searching solid-docs (and solid-site), turns up quite a few links to indepth.dev, which as of now redirects to https://angularindepth.com (although the redirect loses the page).

https://github.com/search?q=org%3Asolidjs%20indepth.dev&type=code

This PR fixes at least the links in this repo.