### PR TITLE
Update getting-started.md to use esm.sh not skypack

### DIFF
--- a/langs/en/guides/getting-started.md
+++ b/langs/en/guides/getting-started.md
@@ -127,12 +127,9 @@ You can run them straight from the browser using [Skypack](https://www.skypack.d
 <html>
   <body>
     <script type="module">
-      import {
-        createSignal,
-        onCleanup,
-      } from "https://cdn.skypack.dev/solid-js";
-      import { render } from "https://cdn.skypack.dev/solid-js/web";
-      import html from "https://cdn.skypack.dev/solid-js/html";
+      import { onCleanup, createSignal } from "https://esm.sh/solid-js@1.8.1";
+      import { render } from "https://esm.sh/solid-js@1.8.1/web";
+      import html from "https://esm.sh/solid-js@1.8.1/html";
 
       const App = () => {
         const [count, setCount] = createSignal(0),
@@ -146,6 +143,7 @@ You can run them straight from the browser using [Skypack](https://www.skypack.d
     </script>
   </body>
 </html>
+
 ```
 
 The advantages of going buildless come with tradeoffs:


### PR DESCRIPTION
### Summary

The example code in getting-started.md under the buildless options heading does not work because skypack is not working with the latest version of solid (1.8.1). This PR updates the example code to use esm.sh instead of skypack

As discussed in this bug in the main solid repo https://github.com/solidjs/solid/issues/1921, skypack is no longer recommended as a buildless option for solid. Esm.sh is now the recommended option.

### Testing

I copied the example code under the **buildless options** heading to a local html file, replaced the skypack urls with esm.sh ones, and opened the html file in a chromium browser, it ran successfully without errors in the console. I then took this code that I verified to run locally, and updated the example code in getting-started.md with it.

